### PR TITLE
Added tests to cover the main function api

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,6 @@ Imports:
     scales,
     dplyr,
     rlang
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/spc.r
+++ b/R/spc.r
@@ -169,7 +169,8 @@ spc <- function(
     "free"
   }
   if(is.null(facet_name)){ # If no facet field specified, bind a pseudo-facet field for grouping/joining purposes
-    f <- data.frame(facet_name = rep("no facet",nrow(df)))
+    facet_name <- "pseudo_facet_col_name"
+    f <- data.frame("pseudo_facet_col_name" = rep("no facet",nrow(df)))
     df <- cbind(df,f)
     message("No facet detected - binding pseudo-facet column")
   }
@@ -208,9 +209,9 @@ spc <- function(
   # Restructure starting data frame
   df <- df %>%
     select(
-      y = y_name
-      ,x = x_name
-      ,f = facet_name
+      y = all_of(y_name)
+      ,x = all_of(x_name)
+      ,f = all_of(facet_name)
       ,rebase = .data$rebase
       ,trajectory = .data$trajectory
       ,target = .data$target) %>%
@@ -442,7 +443,7 @@ spc <- function(
       geom_line(color=.darkgrey,size=pointSize/2.666666) +
       geom_point(color=.darkgrey,size=pointSize)
 
-    if(!(is.null(facet_name))){ # Applt facet wrap if a facet field is present
+    if(facet_name != "pseudo_facet_col_name"){ # Apply facet wrap if a facet field is present
       plot <- plot +
         facet_wrap(vars(f), scales = facetScales)
     }

--- a/R/spc.r
+++ b/R/spc.r
@@ -54,16 +54,6 @@ spc <- function(
   if(!(is.data.frame(data.frame))){ # Check that data.frame argument is a data frame
     stop("Data.frame argument is not a data.frame.")
   }
-  if(!(is.null(options$yAxisBreaks))){ # Y axis breaks should be integer or decimal
-    if(is.numeric(options$yAxisBreaks)){
-      yaxis <- c(df$y,df$upl,df$lpl)
-      start <- floor(min(yaxis,na.rm = TRUE)/options$yAxisBreaks) * options$yAxisBreaks
-      end <- max(yaxis,na.rm = TRUE)
-      yaxislabels <- seq(from = start, to = end, by = options$yAxisBreaks)
-    } else {
-      stop("Y Axis Break option must be numeric.")
-    }
-  }
   if(!(is.null(options$improvementDirection))){ # Check improvement direction supplied is either increase/decrease or 1/-1
     if(options$improvementDirection == "increase" || options$improvementDirection == 1){
       improvementDirection <- 1
@@ -431,6 +421,17 @@ spc <- function(
   .purple = "#361475"
   .red = "#de1b1b"
 
+  if(!(is.null(options$yAxisBreaks))){ # Y axis breaks should be integer or decimal
+    if(is.numeric(options$yAxisBreaks)){
+      yaxis <- c(df$y,df$upl,df$lpl)
+      start <- floor(min(yaxis,na.rm = TRUE)/options$yAxisBreaks) * options$yAxisBreaks
+      end <- max(yaxis,na.rm = TRUE)
+      yaxislabels <- seq(from = start, to = end, by = options$yAxisBreaks)
+    } else {
+      stop("Y Axis Break option must be numeric.")
+    }
+  }
+
   # Create chart if required
   if(outputChart == 1){
     plot <- ggplot(df,aes(x=.data$x,y=.data$y)) +
@@ -458,7 +459,7 @@ spc <- function(
       scale_x_date(breaks=xaxislabels, labels = format(xaxislabels, format = xAxisDateFormat)) +
       theme(axis.text.x = element_text(angle = 90, hjust = 1))
 
-    if(is.null(facet_name)){
+    if(facet_name == "pseudo_facet_col_name"){
       if(convertToPercentages == FALSE){
         if(!(is.null(options$yAxisBreaks))){
           plot <- plot +
@@ -472,9 +473,7 @@ spc <- function(
         plot <- plot +
           scale_y_continuous(labels = scales::percent,breaks = seq(from = 0, to = percentLimit, by = interval))
       }
-    }
-
-    if(!(is.null(facet_name))){
+    } else {
       if(convertToPercentages != 0) {
         percentLimit <- max(df$upl,na.rm = TRUE)
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(NHSRplotthedots)
+
+test_check("NHSRplotthedots")

--- a/tests/testthat/test-spc-function-public-api.R
+++ b/tests/testthat/test-spc-function-public-api.R
@@ -307,24 +307,23 @@ test_that("x axis breaks can be specified", {
   expect_identical(secondXLabel, "29/03/2021") #second label is one week later
 })
 
-#TODO test written, but currently failing.  Investigate code and consider opening issue.
-# test_that("y axis breaks can be specified", {
-#   #arrange
-#   data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
-#   date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
-#   df <- tibble(data, date)
-#
-#   options <- list(
-#     yAxisBreaks = 2
-#   )
-#
-#   #act
-#   result <- suppressMessages(spc(df, "data", "date", options = options)suppressMessages(
-#
-#   #assert
-#   expect_s3_class(result,"ggplot")
-#
-#   firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]] %>% as.numeric()
-#   secondYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[2]] %>% as.numeric()
-#   expect_equal(secondYLabel - firstYLabel, 2) #the difference between labels should be 2
-# })
+test_that("y axis breaks can be specified", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+
+  options <- list(
+    yAxisBreaks = 2
+  )
+
+  #act
+  result <- suppressMessages(spc(df, "data", "date", options = options))
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]] %>% as.numeric()
+  secondYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[2]] %>% as.numeric()
+  expect_equal(secondYLabel - firstYLabel, 2) #the difference between labels should be 2
+})

--- a/tests/testthat/test-spc-function-public-api.R
+++ b/tests/testthat/test-spc-function-public-api.R
@@ -1,0 +1,331 @@
+library(NHSRplotthedots)
+library(stringr)
+
+test_that("spc function can create a ggplot", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+
+  #act
+  result <- spc(df, "data", "date")
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  expect_identical(result$labels$title, "SPC Chart")
+  expect_identical(result$labels$x, "Date")
+  expect_identical(result$labels$y, "Value")
+  expect_identical(ggplot_build(result)$layout$panel_scales_x[[1]]$labels[[1]], "22/03/2021") #default date format
+})
+
+test_that("spc function can create a faceted ggplot", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 24)
+  category <- c(rep("Category A", times = 12), rep("Category B", times = 12))
+  df <- tibble(data, date, category)
+
+  #act
+  result <- spc(df, "data", "date", "category")
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  expect_identical(ggplot_build(result)$layout$panel_params %>% length(), 2L) #there should be 2 facet panels
+
+  plotOneXRange <- ggplot_build(result)$layout$panel_params[[1]]$x$continuous_range
+  plotTwoXRange <- ggplot_build(result)$layout$panel_params[[2]]$x$continuous_range
+  expect_equal(plotOneXRange, plotTwoXRange) #by default the x axis range is the same on all facets
+
+  plotOneYRange <- ggplot_build(result)$layout$panel_params[[1]]$y$continuous_range
+  plotTwoYRange <- ggplot_build(result)$layout$panel_params[[2]]$y$continuous_range
+  expect_equal(plotOneYRange, plotTwoYRange) #by default the y axis range is the same on all facets
+})
+
+test_that("spc function returns a dataframe when options$outputChart is FALSE", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(outputChart = FALSE)
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"tbl")
+})
+
+test_that("ggplot title and axis labels can be modified with options", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(
+    mainTitle = "New Plot Title",
+    xAxisLabel = "New X Label",
+    yAxisLabel = "New Y Label"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  expect_identical(result$labels$title, "New Plot Title")
+  expect_identical(result$labels$x, "New X Label")
+  expect_identical(result$labels$y, "New Y Label")
+})
+
+test_that("limits can be rebased at an intervention point", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  intervention <- c(0,0,0,1,0,0,0,0,0,0,0,0)
+  df <- tibble(data, date, intervention)
+  options = list(
+    rebase = "intervention"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  #TODO add assertions for limit recalculations in data frame and visible lines on plot
+})
+
+test_that("limits can be rebased at multiple intervention points", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  intervention <- c(0,0,0,1,0,0,0,0,0,1,0,0)
+  df <- tibble(data, date, intervention)
+  options = list(
+    rebase = "intervention"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  #TODO add assertions for limit recalculations in data frame and visible lines on plot
+})
+
+test_that("plotting point size can be adjusted", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(
+    pointSize = 4
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  #TODO add assertion for line and point size changes
+})
+
+test_that("improvement direction can be set as 'decrease'", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(
+    improvementDirection = "decrease"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+  #TODO add assertion for point colours
+})
+
+test_that("y axis values can be set as percentages using 'percentageYAxis = TRUE'", {
+  #arrange
+  data <- c(0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,0.8,0.7,0.6)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(
+    percentageYAxis = TRUE
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]]
+  expect_identical(str_detect(firstYLabel, "%"), TRUE) #check there is a % sign in the first y axis label
+})
+
+test_that("y axis values can be set as percentages using 'percentageYAxis = {decimal axis break value}'", {
+  #arrange
+  data <- c(0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,0.8,0.7,0.6)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+  options = list(
+    percentageYAxis = 0.25
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]]
+  expect_identical(str_detect(firstYLabel, "%"), TRUE) #check there is a % sign in the first y axis label
+})
+
+test_that("a target line can be added to the plot", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  target <- rep(15, times = 12)
+  df <- tibble(data, date, target)
+  options = list(
+    target = "target"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  expect_identical(quo_name(result$layers[[3]]$mapping[[1]]), "target") #confirm layer 3 is "target" layer
+  expect_identical(ggplot_build(result)$data[[3]]$y %>% is.na() %>% sum(), 0L ) #zero NAs in the target line data
+})
+
+test_that("a trajectory line can be added to the plot", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  trajectory <- seq(from = 0.1, to = 5, length.out = 12)
+  df <- tibble(data, date, trajectory)
+  options = list(
+    trajectory = "trajectory"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  expect_identical(quo_name(result$layers[[4]]$mapping[[1]]), "trajectory") #confirm layer 4 is "trajectory" layer
+  expect_identical(ggplot_build(result)$data[[4]]$y %>% is.na() %>% sum(), 0L ) #zero NAs in the trajectory data
+})
+
+test_that("facet plots can be plotted with different x axis ranges", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 24)
+  category <- c(rep("Category A", times = 12), rep("Category B", times = 12))
+  df <- tibble(data, date, category)
+  options = list(
+    fixedXAxisMultiple = FALSE
+  )
+
+  #act
+  result <- spc(df, "data", "date", "category", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  plotOneXRange <- ggplot_build(result)$layout$panel_params[[1]]$x$continuous_range
+  plotTwoXRange <- ggplot_build(result)$layout$panel_params[[2]]$x$continuous_range
+  expect_false(plotOneXRange[[1]] == plotTwoXRange[[1]]) #expect the x axis ranges to be different
+})
+
+test_that("facet plots can be plotted with different y axis ranges", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24)
+  date <- rep(seq(as.Date("2021-03-22"), by = 1, length.out = 12), times = 2)
+  category <- c(rep("Category A", times = 12), rep("Category B", times = 12))
+  df <- tibble(data, date, category)
+  options = list(
+    fixedYAxisMultiple = FALSE
+  )
+
+  #act
+  result <- spc(df, "data", "date", "category", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  plotOneYRange <- ggplot_build(result)$layout$panel_params[[1]]$y$continuous_range
+  plotTwoYRange <- ggplot_build(result)$layout$panel_params[[2]]$y$continuous_range
+  expect_false(plotOneYRange[[1]] == plotTwoYRange[[1]]) #expect the y axis ranges to be different
+})
+
+test_that("x axis date format can be specified", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+
+  options <- list(
+    xAxisDateFormat = "%d%b"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  expect_identical(ggplot_build(result)$layout$panel_scales_x[[1]]$labels[[1]], "22Mar") #new date format
+})
+
+test_that("x axis breaks can be specified", {
+  #arrange
+  data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+  date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+  df <- tibble(data, date)
+
+  options <- list(
+    xAxisBreaks = "1 week"
+  )
+
+  #act
+  result <- spc(df, "data", "date", options = options)
+
+  #assert
+  expect_s3_class(result,"ggplot")
+
+  firstXLabel <- ggplot_build(result)$layout$panel_scales_x[[1]]$labels[[1]]
+  secondXLabel <- ggplot_build(result)$layout$panel_scales_x[[1]]$labels[[2]]
+  expect_identical(firstXLabel, "22/03/2021") #first label (as default)
+  expect_identical(secondXLabel, "29/03/2021") #second label is one week later
+})
+
+#TODO test written, but currently failing.  Investigate code and consider opening issue.
+# test_that("y axis breaks can be specified", {
+#   #arrange
+#   data <- c(1,2,3,4,5,6,7,8,9,10,11,12)
+#   date <- seq(as.Date("2021-03-22"), by = 1, length.out = 12)
+#   df <- tibble(data, date)
+#
+#   options <- list(
+#     yAxisBreaks = 2
+#   )
+#
+#   #act
+#   result <- spc(df, "data", "date", options = options)
+#
+#   #assert
+#   expect_s3_class(result,"ggplot")
+#
+#   firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]] %>% as.numeric()
+#   secondYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[2]] %>% as.numeric()
+#   expect_equal(secondYLabel - firstYLabel, 2) #the difference between labels should be 2
+# })

--- a/tests/testthat/test-spc-function-public-api.R
+++ b/tests/testthat/test-spc-function-public-api.R
@@ -1,5 +1,4 @@
 library(NHSRplotthedots)
-library(stringr)
 
 test_that("spc function can create a ggplot", {
   #arrange
@@ -163,7 +162,7 @@ test_that("y axis values can be set as percentages using 'percentageYAxis = TRUE
   expect_s3_class(result,"ggplot")
 
   firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]]
-  expect_identical(str_detect(firstYLabel, "%"), TRUE) #check there is a % sign in the first y axis label
+  expect_identical(grepl("%", firstYLabel, fixed = TRUE), TRUE) #check there is a % sign in the first y axis label
 })
 
 test_that("y axis values can be set as percentages using 'percentageYAxis = {decimal axis break value}'", {
@@ -182,7 +181,7 @@ test_that("y axis values can be set as percentages using 'percentageYAxis = {dec
   expect_s3_class(result,"ggplot")
 
   firstYLabel <- ggplot_build(result)$layout$panel_scales_y[[1]]$break_info()$labels[[1]]
-  expect_identical(str_detect(firstYLabel, "%"), TRUE) #check there is a % sign in the first y axis label
+  expect_identical(grepl("%", firstYLabel, fixed = TRUE), TRUE) #check there is a % sign in the first y axis label
 })
 
 test_that("a target line can be added to the plot", {


### PR DESCRIPTION
Added tests to cover the main spc() function api.  

All tests will all catch the failure to return a ggplot2 object.  
Most have additional assertions, but several have TODOs for future work to make them more robust:
* The limit recalc tests could be made more explicit (checking upl, lpl, & mean before and after the recalc)
* Line and point size changes are not explicitly checked
* Point colours are not explicitly checked

Testthat threw a warning about "using external vector in selections is ambiguous", so I made minor changes to spc.R to fix that.  
