### PR TITLE
Issue #42 - Change rebase API to allow calling with dates

### DIFF
--- a/R/isDate.r
+++ b/R/isDate.r
@@ -1,0 +1,6 @@
+isDate <- function(x, format = "%Y-%m-%d") {
+  formatted <- try(as.Date(x, format), silent = TRUE)
+  isDate <- as.character(formatted) == x & !is.na(formatted)  # valid and identical to input
+  isDate[is.na(x)] <- NA  # Insert NA for NA in x
+  return(isDate)
+}

--- a/R/spcOptions.r
+++ b/R/spcOptions.r
@@ -7,10 +7,10 @@
 #' the spc function, with the options listed within spcOptions.  See examples below.
 #'
 #'
-#' @param rebase Specify a field name which contains a control limit rebasing flag.
-#'     This field should contain integer values 0 and 1, and any date value where the rebase field is 1 will
-#'     trigger a recalculation of the control limits.
-#'     Field name can be specified using non-standard evaluation (i.e. no quotation marks).
+#' @param rebase Specify either 1) a vector of dates in format "%Y-%m-%d" which will be used to rebase chart
+#'     (including all facets) at the same date intervals, or 2) a field name which contains a control limit
+#'     rebasing flag. If a field name, the field should contain integer values 0 and 1, and any date value
+#'     where the rebase field is 1 will trigger a recalculation of the control limits.
 #' @param fixAfterNPoints Specify a number points after which to fix SPC calculations.
 #' @param improvementDirection Specify whether an increase or decrease in measured variable signifies
 #'     process improvement. Accepted values are 1 or 'increase' for increase as improvement or -1 or 'decrease' for

--- a/R/spcStandard.r
+++ b/R/spcStandard.r
@@ -26,21 +26,9 @@
 spcStandard <- function(.data, valueField, dateField, facetField = NULL, options = NULL) {
 
   # Identify a rebase, trajectory and target fields, if provided in SPC options object
-  rebaseField <- options$rebase[[1]]
+  rebaseField <- options$rebase
   trajectoryField <- options$trajectory[[1]]
   targetField <- options$target[[1]]
-
-  # Declare improvement direction as integer
-  # TODO: This is not used! Is it meant to be?
-  if (!(is.null(options$improvementDirection))) {
-    if (options$improvementDirection == "increase" || options$improvementDirection == 1) {
-      improvementDirection <- 1
-    } else if (options$improvementDirection == "decrease" || options$improvementDirection == -1) {
-      improvementDirection <- -1
-    }
-  } else {
-    improvementDirection <- 1
-  }
 
   # set trajectory field
   if (!(is.null(trajectoryField))) {
@@ -64,9 +52,14 @@ spcStandard <- function(.data, valueField, dateField, facetField = NULL, options
 
   # Set rebase field or create pseudo
   if (!(is.null(rebaseField))) {
-    .data$rebase <- .data[[rebaseField]]
+    if (rebaseField[[1]] %in% names(.data)) {
+      .data$rebase <- .data[[rebaseField[[1]]]]
+    } else if (all(isDate(rebaseField))) {
+      dates <- .data[[dateField]]
+      .data$rebase <- as.integer(as.Date(dates) %in% as.Date(rebaseField))
+    }
   } else {
-    .data$rebase <- rep(0, nrow(.data)) # If no rebase field supplied, create an empty rebase field (all NAs)
+    .data$rebase <- rep(0, nrow(.data))
   }
 
   # Check validity of rebase field supplied - should be 1s and 0s only -

--- a/R/validateParameters.R
+++ b/R/validateParameters.R
@@ -40,16 +40,18 @@ validateParameters <- function(df, valueField, dateField, facetField, options) {
     if (!(is.list(options))) stop("spc: options argument must be of type 'list'.")
   }
 
-  # if provided, options$rebase must be of character type, length 1, and a column name from within the data frame
+  # if provided, options$rebase must be of character type, length 1, and a column name from within the data frame OR a vector of dates
   if (!is.null(options$rebase)) {
-    if (!is.character(options$rebase)) {
-      stop("spc: options$rebase argument must be of type 'character'.")
-    }
-    if (length(options$rebase) > 1) {
-      stop("spc: options$rebase argument must be a vector of length 1.")
-    }
-    if (!(options$rebase %in% colnames(df))) {
-      stop("spc: options$rebase argument must be a column name from the data frame.")
+    if(!all(isDate(options$rebase))){
+      if (!is.character(options$rebase)) {
+        stop("spc: options$rebase argument must be of type 'character'.")
+      }
+      if (length(options$rebase) > 1) {
+        stop("spc: options$rebase argument must be either: 1) a vector of length 1 specifying a column name from within the dataset, or 2) a vector of dates in '%Y-%m-%d' format.")
+      }
+      if (!(options$rebase %in% colnames(df))) {
+        stop("spc: options$rebase argument must be either: 1) a vector of length 1 specifying a column name from within the dataset, or 2) a vector of dates in '%Y-%m-%d' format.")
+      }
     }
   }
 

--- a/man/spcOptions.Rd
+++ b/man/spcOptions.Rd
@@ -24,10 +24,10 @@ spcOptions(
 )
 }
 \arguments{
-\item{rebase}{Specify a field name which contains a control limit rebasing flag.
-This field should contain integer values 0 and 1, and any date value where the rebase field is 1 will
-trigger a recalculation of the control limits.
-Field name can be specified using non-standard evaluation (i.e. no quotation marks).}
+\item{rebase}{Specify either 1) a vector of dates in format "%Y-%m-%d" which will be used to rebase chart (including all facets) at the same date intervals,
+or 2) a field name which contains a control limit rebasing flag.
+If a field name, the field should contain integer values 0 and 1, and any date value where the rebase field is 1 will
+trigger a recalculation of the control limits.}
 
 \item{fixAfterNPoints}{Specify a number points after which to fix SPC calculations.}
 


### PR DESCRIPTION
Amendment to the rebase functionality in spcStandard() so that either a field name can be specified, as currently, or a vector of dates in format %Y/%m/%d which can control rebasing instead. The vector of dates is used to derive a 0/1 field in the data frame so that the remainder of the function works in the same way as at present. 