### PR TITLE
support tidyeval

### DIFF
--- a/R/ptd_spc.R
+++ b/R/ptd_spc.R
@@ -39,7 +39,7 @@
 #' @importFrom rlang .data
 #' @examples
 #' library(NHSRdatasets)
-#' library(tidyverse)
+#' library(dplyr)
 #' data("ae_attendances")
 #'
 #' # Pick a trust at random to look at their data for two years

--- a/R/ptd_spc.R
+++ b/R/ptd_spc.R
@@ -71,16 +71,22 @@
 ptd_spc <- function(.data,
                     value_field,
                     date_field,
-                    facet_field = NULL,
+                    facet_field,
                     rebase = ptd_rebase(),
                     fix_after_n_points = NULL,
                     improvement_direction = "increase",
-                    target = NULL,
-                    trajectory = NULL) {
+                    target,
+                    trajectory) {
   assertthat::assert_that(
     inherits(.data, "data.frame"),
     msg = "ptd_spc: .data must be a data.frame"
   )
+
+  value_field <- quo_name(enquo(value_field))
+  date_field <- quo_name(enquo(date_field))
+  facet_field <- if (!missing(facet_field)) quo_name(enquo(facet_field))
+  target <- if (!missing(target)) quo_name(enquo(target))
+  trajectory <- if (!missing(trajectory)) quo_name(enquo(trajectory))
 
   # validate all inputs.  Validation problems will generate an error and stop code execution.
   options <- ptd_spc_options(

--- a/R/ptd_spc.R
+++ b/R/ptd_spc.R
@@ -39,6 +39,7 @@
 #' @importFrom rlang .data
 #' @examples
 #' library(NHSRdatasets)
+#' library(tidyverse)
 #' data("ae_attendances")
 #'
 #' # Pick a trust at random to look at their data for two years
@@ -46,17 +47,17 @@
 #'
 #' # Basic chart with improvement direction decreasing
 #' ptd_spc(trust1,
-#'   value_field = "breaches", date_field = "period",
+#'   value_field = breaches, date_field = period,
 #'   improvement_direction = "decrease"
 #' )
 #'
 #' # Pick a few trust, and plot individually using facet
 #' # Also set the x-axis scale to vary for each and date groups to 3 months
-#' orgs <- ae_attendances$org_code %in% c("RAS", "RJZ", "RR1", "RJC", "RQ1")
-#' trusts4 <- subset(ae_attendances, orgs & type == 1)
+#' orgs <- c("RAS", "RJZ", "RR1", "RJC", "RQ1")
+#' trusts4 <- filter(ae_attendances, org_code %in% orgs, type == 1)
 #'
 #' s <- ptd_spc(trusts4,
-#'   value_field = "breaches", date_field = "period", facet_field = "org_code",
+#'   value_field = breaches, date_field = period, facet_field = org_code,
 #'   improvement_direction = "decrease"
 #' )
 #' plot(s, fixed_y_axis_multiple = FALSE, x_axis_breaks = "3 months")

--- a/R/ptd_spc_colours.R
+++ b/R/ptd_spc_colours.R
@@ -12,8 +12,7 @@
 #' @return a list of colours
 #'
 #' @export
-ptd_spc_colours <- function( # Begin Exclude Linting
-                            common_cause = "#7B7D7D",
+ptd_spc_colours <- function(common_cause = "#7B7D7D",
                             special_cause_improvement = "#289de0",
                             special_cause_concern = "#fab428",
                             value_line = "#7B7D7D",
@@ -21,9 +20,7 @@ ptd_spc_colours <- function( # Begin Exclude Linting
                             lpl = "#7B7D7D",
                             upl = "#7B7D7D",
                             target = "#361475",
-                            trajectory = "#de1b1b"
-                            # End Exclude Linting
-) {
+                            trajectory = "#de1b1b") {
   structure(
     list(
       common_cause              = common_cause,

--- a/man/ptd_spc.Rd
+++ b/man/ptd_spc.Rd
@@ -60,6 +60,7 @@ logic produced by NHSI. The function can return either a plot or data frame.
 }
 \examples{
 library(NHSRdatasets)
+library(tidyverse)
 data("ae_attendances")
 
 # Pick a trust at random to look at their data for two years
@@ -67,17 +68,17 @@ trust1 <- subset(ae_attendances, org_code == "RJZ" & type == 1)
 
 # Basic chart with improvement direction decreasing
 ptd_spc(trust1,
-  value_field = "breaches", date_field = "period",
+  value_field = breaches, date_field = period,
   improvement_direction = "decrease"
 )
 
 # Pick a few trust, and plot individually using facet
 # Also set the x-axis scale to vary for each and date groups to 3 months
-orgs <- ae_attendances$org_code \%in\% c("RAS", "RJZ", "RR1", "RJC", "RQ1")
-trusts4 <- subset(ae_attendances, orgs & type == 1)
+orgs <- c("RAS", "RJZ", "RR1", "RJC", "RQ1")
+trusts4 <- filter(ae_attendances, org_code \%in\% orgs, type == 1)
 
 s <- ptd_spc(trusts4,
-  value_field = "breaches", date_field = "period", facet_field = "org_code",
+  value_field = breaches, date_field = period, facet_field = org_code,
   improvement_direction = "decrease"
 )
 plot(s, fixed_y_axis_multiple = FALSE, x_axis_breaks = "3 months")

--- a/man/ptd_spc.Rd
+++ b/man/ptd_spc.Rd
@@ -60,7 +60,7 @@ logic produced by NHSI. The function can return either a plot or data frame.
 }
 \examples{
 library(NHSRdatasets)
-library(tidyverse)
+library(dplyr)
 data("ae_attendances")
 
 # Pick a trust at random to look at their data for two years

--- a/man/ptd_spc.Rd
+++ b/man/ptd_spc.Rd
@@ -8,12 +8,12 @@ ptd_spc(
   .data,
   value_field,
   date_field,
-  facet_field = NULL,
+  facet_field,
   rebase = ptd_rebase(),
   fix_after_n_points = NULL,
   improvement_direction = "increase",
-  target = NULL,
-  trajectory = NULL
+  target,
+  trajectory
 )
 }
 \arguments{

--- a/tests/testthat/test-ptd_spc.R
+++ b/tests/testthat/test-ptd_spc.R
@@ -54,9 +54,9 @@ test_that("it has options as an attribute, created by ptd_spc_options", {
   })
 
   s <- ptd_spc(data, "a", "b", "c", "d", "e", "f", "g", "h")
-  options <- attr(s, "options")
+  o <- attr(s, "options")
 
-  expect_equal(options, spc_options)
+  expect_equal(o, spc_options)
   expect_called(m, 1)
   expect_args(m, 1, "a", "b", "c", "d", "e", "f", "g", "h")
 })
@@ -172,6 +172,24 @@ test_that("it calls ptd_add_rebase_column", {
 
   expect_called(m, 1)
   expect_args(m, 1, data, "x", "f", "r")
+})
+
+test_that("it accepts nse arguments as well as string", {
+  m <- mock(spc_options, spc_options)
+
+  stub(ptd_spc, "ptd_spc_options", m)
+  stub(ptd_spc, "ptd_validate_spc_options", TRUE)
+  stub(ptd_spc, "ptd_spc_standard", function(x, ...) x)
+  stub(ptd_spc, "ptd_calculate_point_type", function(x, ...) x)
+  stub(ptd_spc, "to_datetime", function(x, ...) x)
+
+  s1 <- ptd_spc(data, vf, df)
+  s2 <- ptd_spc(data, value_field = vf, date_field = df, facet_field = ff, rebase = ptd_rebase(), target = ta,
+                trajectory = tr)
+
+  expect_called(m, 2)
+  expect_args(m, 1, "vf", "df", NULL, NULL, NULL, "increase", NULL, NULL)
+  expect_args(m, 2, "vf", "df", "ff", ptd_rebase(), NULL, "increase", "ta", "tr")
 })
 
 # print() ----

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -37,7 +37,7 @@ library(scales)
 data("ae_attendances")
 
 ae_attendances %>% 
-  filter(org_code == "RRK" & type == 1) %>% 
+  filter(org_code == "RRK", type == 1) %>% 
   ggplot(aes(x = period, y = breaches)) +
   geom_point() +
   geom_line() +
@@ -59,7 +59,7 @@ stable_set <- ae_attendances %>%
          type ==1,
          period < as.Date("2018-04-01"))
 
-ptd_spc(stable_set, value_field = "breaches", date_field = "period", improvement_direction = "decrease")
+ptd_spc(stable_set, value_field = breaches, date_field = period, improvement_direction = "decrease")
 ```
 
 From the chart above, we can see the centre line (mean) and the control limits calculated according the the XmR chart rules.  Our points that are between the control limits are within control and showing 'common-cause' or 'natural' variation.  We can see 8 sequential points coloured in yellow.  This is triggered by a rule that looks for >=7 points on one side of the mean.  This could be viewed as a period where fewer breaches than average were detected, which may hold some learning value for the organisation.
@@ -74,8 +74,8 @@ change_set <- ae_attendances %>%
   filter(org_code == "RRK", type == 1)
 
 ptd_spc(change_set,
-        value_field = "breaches",
-        date_field = "period",
+        value_field = breaches,
+        date_field = period,
         improvement_direction = "decrease",
         rebase = ptd_rebase(as.Date("2018-07-01")))
 ```
@@ -97,9 +97,9 @@ facet_set <-
          period < as.Date("2018-04-01"))
 
 ptd_spc(facet_set,
-        value_field = "breaches",
-        date_field = "period",
-        facet_field = "org_code",
+        value_field = breaches,
+        date_field = period,
+        facet_field = org_code,
         improvement_direction = "decrease") %>%
   plot(fixed_y_axis_multiple = FALSE, x_axis_breaks = "3 months")
 
@@ -112,11 +112,10 @@ facet_set <- ae_attendances %>%
          type == 1,
          period < as.Date("2018-04-01"))
 
-
 ptd_spc(facet_set,
-        value_field = "breaches",
-        date_field = "period",
-        facet_field = "org_code", 
+        value_field = breaches,
+        date_field = period,
+        facet_field = org_code, 
         improvement_direction = "decrease") %>%
   plot(fixed_y_axis_multiple = FALSE,
        x_axis_breaks = "3 months",
@@ -133,9 +132,9 @@ facet_set <- ae_attendances %>%
          period < as.Date("2018-04-01"))
 
 a <- ptd_spc(facet_set,
-             value_field = "breaches",
-             date_field = "period",
-             facet_field = "org_code",
+             value_field = breaches,
+             date_field = period,
+             facet_field = org_code,
              improvement_direction = "decrease") %>%
   plot(fixed_y_axis_multiple = FALSE,
        x_axis_breaks = "3 months",


### PR DESCRIPTION
allows for field arguments to either be passed as strings, or as unevaluated symbols (e.g. tidyeval)

closes #62

- [x] added unit tests and checked code coverage with `covr::report()` (should aim for 100%)
- [x] ran `devtools::document()`
- [x] ran `lintr::lint_package()` and resolved all lint warnings and notes
- [x] ran `styler::style_pkg()` to make sure code matches the style guidelines
- [x] ran R-CMD CHECK and resolved all issues
