### PR TITLE
adds ability to screen outliers from process limit calculation

### DIFF
--- a/R/ptd_spc.R
+++ b/R/ptd_spc.R
@@ -27,6 +27,8 @@
 #'     Field name can be specified using non-standard evaluation (i.e. no quotation marks).
 #' @param trajectory Specify a field name which contains a trajectory value.
 #'     Field name can be specified using non-standard evaluation (i.e. no quotation marks).
+#' @param screen_outliers Whether we should screen for outliers or not when calculating the control limits. Defaults to
+#'     `TRUE`.
 #'
 #' @export ptd_spc
 #'
@@ -76,7 +78,8 @@ ptd_spc <- function(.data,
                     fix_after_n_points = NULL,
                     improvement_direction = "increase",
                     target = NULL,
-                    trajectory = NULL) {
+                    trajectory = NULL,
+                    screen_outliers = TRUE) {
   assertthat::assert_that(
     inherits(.data, "data.frame"),
     msg = "ptd_spc: .data must be a data.frame"
@@ -85,7 +88,7 @@ ptd_spc <- function(.data,
   # validate all inputs.  Validation problems will generate an error and stop code execution.
   options <- ptd_spc_options(
     value_field, date_field, facet_field, rebase, fix_after_n_points, improvement_direction, target,
-    trajectory
+    trajectory, screen_outliers
   )
 
   ptd_validate_spc_options(options, .data)

--- a/R/ptd_spc_options.R
+++ b/R/ptd_spc_options.R
@@ -16,7 +16,8 @@ ptd_spc_options <- function(value_field,
                             fix_after_n_points = NULL,
                             improvement_direction = c("increase", "decrease"),
                             target = NULL,
-                            trajectory = NULL) {
+                            trajectory = NULL,
+                            screen_outliers = TRUE) {
   assertthat::assert_that(
     is.character(value_field),
     assertthat::is.scalar(value_field),
@@ -80,6 +81,12 @@ ptd_spc_options <- function(value_field,
     )
   }
 
+  assertthat::assert_that(
+    is.logical(screen_outliers),
+    assertthat::is.scalar(screen_outliers),
+    msg = "screen_outliers must either `TRUE` or `FALSE`."
+  )
+
   # TODO: check that this is correct
   assertthat::assert_that(
     is.null(fix_after_n_points) || is.null(rebase),
@@ -95,7 +102,8 @@ ptd_spc_options <- function(value_field,
       fix_after_n_points = fix_after_n_points,
       improvement_direction = improvement_direction,
       target = target,
-      trajectory = trajectory
+      trajectory = trajectory,
+      screen_outliers = screen_outliers
     ),
     class = "ptd_spc_options"
   )
@@ -129,6 +137,7 @@ print.ptd_spc_options <- function(x, ...) {
     f("improvement_direction"),
     f("target"),
     f("trajectory"),
+    f("screen_outliers"),
     paste(rep("-", l), collapse = "")
   )
 

--- a/man/ptd_spc.Rd
+++ b/man/ptd_spc.Rd
@@ -13,7 +13,8 @@ ptd_spc(
   fix_after_n_points = NULL,
   improvement_direction = "increase",
   target = NULL,
-  trajectory = NULL
+  trajectory = NULL,
+  screen_outliers = TRUE
 )
 }
 \arguments{
@@ -45,6 +46,9 @@ Field name can be specified using non-standard evaluation (i.e. no quotation mar
 
 \item{trajectory}{Specify a field name which contains a trajectory value.
 Field name can be specified using non-standard evaluation (i.e. no quotation marks).}
+
+\item{screen_outliers}{Whether we should screen for outliers or not when calculating the control limits. Defaults to
+\code{TRUE}.}
 }
 \value{
 A ggplot2 object of the spc charts.  This will automatically print the plot, but can also be saved as an

--- a/tests/testthat/_snaps/ptd_spc.md
+++ b/tests/testthat/_snaps/ptd_spc.md
@@ -10,6 +10,7 @@
     improvement_direction:'increase'
     target:               not set
     trajectory:           not set
+    screen_outliers:      'TRUE'
     --------------------------------
     # A tibble: 1 x 7
        mean   lpl   upl     n common_cause special_cause_improve~ special_cause_con~
@@ -28,6 +29,7 @@
     improvement_direction:'increase'
     target:               not set
     trajectory:           not set
+    screen_outliers:      'TRUE'
     --------------------------------
     # A tibble: 1 x 8
       rebase_group  mean   lpl   upl     n common_cause special_cause_improvement
@@ -47,6 +49,7 @@
     improvement_direction:'increase'
     target:               not set
     trajectory:           not set
+    screen_outliers:      'TRUE'
     --------------------------------
     # A tibble: 2 x 8
           f   mean   lpl   upl     n common_cause special_cause_im~ special_cause_c~
@@ -66,6 +69,7 @@
     improvement_direction:'increase'
     target:               not set
     trajectory:           not set
+    screen_outliers:      'TRUE'
     --------------------------------
     # A tibble: 2 x 9
           f rebase_group   mean   lpl   upl     n common_cause special_cause_improv~

--- a/tests/testthat/_snaps/ptd_spc_standard.md
+++ b/tests/testthat/_snaps/ptd_spc_standard.md
@@ -1,7 +1,7 @@
 # it returns expected values
 
     Code
-      r
+      r1
     Output
       # A tibble: 20 x 13
                y x          f       trajectory target rebase_group   fix_y  mean   lpl
@@ -26,6 +26,68 @@
       18 -1.97   2020-01-19 no fac~         NA     NA            0 -1.97   0.142 -3.01
       19  0.701  2020-01-20 no fac~         NA     NA            0  0.701  0.142 -3.01
       20 -0.473  2020-01-21 no fac~         NA     NA            0 -0.473  0.142 -3.01
+      # ... with 4 more variables: upl <dbl>, outside_limits <lgl>,
+      #   relative_to_mean <dbl>, close_to_limits <lgl>
+
+---
+
+    Code
+      r2
+    Output
+      # A tibble: 20 x 13
+               y x          f       trajectory target rebase_group   fix_y  mean   lpl
+           <dbl> <date>     <chr>        <dbl>  <dbl>        <dbl>   <dbl> <dbl> <dbl>
+       1 -0.560  2020-01-02 no fac~         NA     NA            0 -0.560  0.669 -2.38
+       2 -0.230  2020-01-03 no fac~         NA     NA            0 -0.230  0.669 -2.38
+       3  1.56   2020-01-04 no fac~         NA     NA            0  1.56   0.669 -2.38
+       4  0.0705 2020-01-05 no fac~         NA     NA            0  0.0705 0.669 -2.38
+       5  0.129  2020-01-06 no fac~         NA     NA            0  0.129  0.669 -2.38
+       6  1.72   2020-01-07 no fac~         NA     NA            0  1.72   0.669 -2.38
+       7  0.461  2020-01-08 no fac~         NA     NA            0  0.461  0.669 -2.38
+       8 -1.27   2020-01-09 no fac~         NA     NA            0 -1.27   0.669 -2.38
+       9 -0.687  2020-01-10 no fac~         NA     NA            0 -0.687  0.669 -2.38
+      10 -0.446  2020-01-11 no fac~         NA     NA            0 -0.446  0.669 -2.38
+      11  1.22   2020-01-12 no fac~         NA     NA            0  1.22   0.669 -2.38
+      12  0.360  2020-01-13 no fac~         NA     NA            0  0.360  0.669 -2.38
+      13  0.401  2020-01-14 no fac~         NA     NA            0  0.401  0.669 -2.38
+      14  0.111  2020-01-15 no fac~         NA     NA            0  0.111  0.669 -2.38
+      15 10      2020-01-16 no fac~         NA     NA            0 10      0.669 -2.38
+      16  1.79   2020-01-17 no fac~         NA     NA            0  1.79   0.669 -2.38
+      17  0.498  2020-01-18 no fac~         NA     NA            0  0.498  0.669 -2.38
+      18 -1.97   2020-01-19 no fac~         NA     NA            0 -1.97   0.669 -2.38
+      19  0.701  2020-01-20 no fac~         NA     NA            0  0.701  0.669 -2.38
+      20 -0.473  2020-01-21 no fac~         NA     NA            0 -0.473  0.669 -2.38
+      # ... with 4 more variables: upl <dbl>, outside_limits <lgl>,
+      #   relative_to_mean <dbl>, close_to_limits <lgl>
+
+---
+
+    Code
+      r3
+    Output
+      # A tibble: 20 x 13
+               y x          f       trajectory target rebase_group   fix_y  mean   lpl
+           <dbl> <date>     <chr>        <dbl>  <dbl>        <dbl>   <dbl> <dbl> <dbl>
+       1 -0.560  2020-01-02 no fac~         NA     NA            0 -0.560  0.669 -4.60
+       2 -0.230  2020-01-03 no fac~         NA     NA            0 -0.230  0.669 -4.60
+       3  1.56   2020-01-04 no fac~         NA     NA            0  1.56   0.669 -4.60
+       4  0.0705 2020-01-05 no fac~         NA     NA            0  0.0705 0.669 -4.60
+       5  0.129  2020-01-06 no fac~         NA     NA            0  0.129  0.669 -4.60
+       6  1.72   2020-01-07 no fac~         NA     NA            0  1.72   0.669 -4.60
+       7  0.461  2020-01-08 no fac~         NA     NA            0  0.461  0.669 -4.60
+       8 -1.27   2020-01-09 no fac~         NA     NA            0 -1.27   0.669 -4.60
+       9 -0.687  2020-01-10 no fac~         NA     NA            0 -0.687  0.669 -4.60
+      10 -0.446  2020-01-11 no fac~         NA     NA            0 -0.446  0.669 -4.60
+      11  1.22   2020-01-12 no fac~         NA     NA            0  1.22   0.669 -4.60
+      12  0.360  2020-01-13 no fac~         NA     NA            0  0.360  0.669 -4.60
+      13  0.401  2020-01-14 no fac~         NA     NA            0  0.401  0.669 -4.60
+      14  0.111  2020-01-15 no fac~         NA     NA            0  0.111  0.669 -4.60
+      15 10      2020-01-16 no fac~         NA     NA            0 10      0.669 -4.60
+      16  1.79   2020-01-17 no fac~         NA     NA            0  1.79   0.669 -4.60
+      17  0.498  2020-01-18 no fac~         NA     NA            0  0.498  0.669 -4.60
+      18 -1.97   2020-01-19 no fac~         NA     NA            0 -1.97   0.669 -4.60
+      19  0.701  2020-01-20 no fac~         NA     NA            0  0.701  0.669 -4.60
+      20 -0.473  2020-01-21 no fac~         NA     NA            0 -0.473  0.669 -4.60
       # ... with 4 more variables: upl <dbl>, outside_limits <lgl>,
       #   relative_to_mean <dbl>, close_to_limits <lgl>
 

--- a/tests/testthat/test-ptd_spc.R
+++ b/tests/testthat/test-ptd_spc.R
@@ -53,12 +53,12 @@ test_that("it has options as an attribute, created by ptd_spc_options", {
     x
   })
 
-  s <- ptd_spc(data, "a", "b", "c", "d", "e", "f", "g", "h")
+  s <- ptd_spc(data, "a", "b", "c", "d", "e", "f", "g", "h", "i")
   options <- attr(s, "options")
 
   expect_equal(options, spc_options)
   expect_called(m, 1)
-  expect_args(m, 1, "a", "b", "c", "d", "e", "f", "g", "h")
+  expect_args(m, 1, "a", "b", "c", "d", "e", "f", "g", "h", "i")
 })
 
 test_that("it validates the options", {

--- a/tests/testthat/test-ptd_spc_options.R
+++ b/tests/testthat/test-ptd_spc_options.R
@@ -10,7 +10,8 @@ test_that("it returns correct data", {
     fix_after_n_points = NULL,
     improvement_direction = "increase",
     target = "target",
-    trajectory = "trajectory"
+    trajectory = "trajectory",
+    screen_outliers = TRUE
   )
 
   expect_equal(r$value_field, "value_field")
@@ -21,6 +22,7 @@ test_that("it returns correct data", {
   expect_equal(r$improvement_direction, "increase")
   expect_equal(r$target, "target")
   expect_equal(r$trajectory, "trajectory")
+  expect_equal(r$screen_outliers, TRUE)
 
   expect_s3_class(r, "ptd_spc_options")
 })
@@ -122,6 +124,23 @@ test_that("trajectory is either null, or a scalar character", {
   )
 })
 
+test_that("screen_outliers must be a scalar logical", {
+  # this should run without an error
+  ptd_spc_options("a", "b", screen_outliers = TRUE)
+  ptd_spc_options("a", "b", screen_outliers = FALSE)
+
+  # this should error
+  em <- "screen_outliers must either `TRUE` or `FALSE`."
+  expect_error(
+    ptd_spc_options("a", "b", screen_outliers = c(TRUE, FALSE)),
+    em
+  )
+  expect_error(
+    ptd_spc_options("a", "b", screen_outliers = "TRUE"),
+    em
+  )
+})
+
 test_that("you cannot rebase and fix_after_n_points", {
   expect_error(
     ptd_spc_options("b", "a", rebase = as.Date("2020-04-01"), fix_after_n_points = 12),
@@ -143,5 +162,6 @@ test_that("printing output", {
   expect_output(print(r), "improvement_direction:.*not set")
   expect_output(print(r), "target:.*not set")
   expect_output(print(r), "trajectory:.*not set")
+  expect_output(print(r), "screen_outliers:.*'TRUE'")
   expect_output(print(r), "--------------------------------")
 })

--- a/tests/testthat/test-ptd_spc_standard.R
+++ b/tests/testthat/test-ptd_spc_standard.R
@@ -8,59 +8,93 @@ data <- data.frame(
   rebase = 0,
   t = 1:20
 )
+spc_options <- list(value_field = "y", date_field = "x", screen_outliers = TRUE)
 
 test_that("it returns a data frame", {
-  r <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  r <- ptd_spc_standard(data, spc_options)
 
   expect_s3_class(r, "data.frame")
 })
 
 test_that("it returns expected values", {
-  r <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  r1 <- ptd_spc_standard(data, spc_options)
 
-  expect_snapshot(r)
+  expect_snapshot(r1)
+
+  # testing the screen_outliers
+  o <- spc_options
+  data$y[15] <- 10
+  r2 <- ptd_spc_standard(data, o)
+  expect_snapshot(r2)
+
+  o$screen_outliers <- FALSE
+  r3 <- ptd_spc_standard(data, o)
+  expect_snapshot(r3)
+
+  # check that we have different limits for all of the results
+  expect_true(r1$lpl[[1]] != r2$lpl[[1]])
+  expect_true(r1$lpl[[1]] != r3$lpl[[1]])
+  expect_true(r2$lpl[[1]] != r3$lpl[[1]])
+  expect_true(r1$upl[[1]] != r2$upl[[1]])
+  expect_true(r1$upl[[1]] != r3$upl[[1]])
+  expect_true(r2$upl[[1]] != r3$upl[[1]])
+
+  # check that the range in the 3rd results (when screen_outliers = FALSE) is larger than the range in the 2nd results
+  # (when screen_outliers = TRUE)
+  expect_true(r3$upl[[1]] - r3$lpl[[1]] > r2$upl[[1]] - r2$lpl[[1]])
 })
 
 test_that("it sets the trajectory field", {
+  o <- spc_options
+  o$trajectory <- "t"
   # when options$trajectory is set
-  r1 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x", trajectory = "t"))
+  r1 <- ptd_spc_standard(data, o)
   expect_equal(r1$trajectory, 1:20)
 
   # when options$trajectory is not set
-  r2 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  o$trajectory <- NULL
+  r2 <- ptd_spc_standard(data, o)
   expect_equal(r2$trajectory, rep(as.double(NA), 20))
 })
 
 test_that("it sets the target field", {
+  o <- spc_options
+  o$target <- "t"
   # when options$target is set
-  r1 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x", target = "t"))
+  r1 <- ptd_spc_standard(data, o)
   expect_equal(r1$target, 1:20)
 
   # when options$target is not set
-  r2 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  o$target <- NULL
+  r2 <- ptd_spc_standard(data, o)
   expect_equal(r2$target, rep(as.double(NA), 20))
 })
 
 test_that("it creates the pseudo facet column if no facet_field is set", {
   # when options$target is not set
-  r2 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
-  expect_equal(r2$f, rep("no facet", 20))
+  r <- ptd_spc_standard(data, spc_options)
+  expect_equal(r$f, rep("no facet", 20))
 })
 
 test_that("it sets the rebase_group field", {
+  o <- spc_options
   # when rebase is not set
-  r1 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  r1 <- ptd_spc_standard(data, o)
   expect_equal(r1$rebase_group, rep(0, 20))
 
   # when rebase is set
+  o$rebase <- "rebase"
   data <- mutate(data, rebase = c(rep(0, 10), 1, rep(0, 9)))
-  r2 <- ptd_spc_standard(data, list(value_field = "y", date_field = "x"))
+  r2 <- ptd_spc_standard(data, o)
   expect_equal(r2$rebase_group, c(rep(0, 10), rep(1, 10)))
 })
 
 test_that("setting fix_after_n_points changes the calculations", {
-  s0 <- ptd_spc_standard(data, ptd_spc_options("y", "x"))
-  s1 <- ptd_spc_standard(data, ptd_spc_options("y", "x", fix_after_n_points = 12))
+  o <- spc_options
+  s0 <- ptd_spc_standard(data, o)
+
+  o$fix_after_n_points <- 12
+  s1 <- ptd_spc_standard(data, o)
 
   expect_true(s1$lpl[[1]] != s0$lpl[[1]])
   expect_true(s1$upl[[1]] != s0$upl[[1]])


### PR DESCRIPTION
- [ ] added unit tests and checked code coverage with `covr::report()` (should aim for 100%)
- [ ] ran `devtools::document()`
- [ ] ran `lintr::lint_package()` and resolved all lint warnings and notes
- [ ] ran `styler::style_pkg()` to make sure code matches the style guidelines
- [ ] ran R-CMD CHECK and resolved all issues

adds an argument to control whether we should screen outliers from process limit calculations. As per [1].

todo: could probably do with a bit of a better explanation in the documentation as to how this works, why it's enabled. Also need to decide if we want the default to be TRUE

[1]: Nelson, LS, 'Shewhart charts for Individual Measurements" Journal of Quality Technology, 1982, i3, 172-173