### PR TITLE
Issue #84 - fixes target and trajectory line colours

### DIFF
--- a/R/ptd_spc_colours.R
+++ b/R/ptd_spc_colours.R
@@ -19,8 +19,8 @@ ptd_spc_colours <- function(common_cause = "#7B7D7D",
                             mean_line = "#000000",
                             lpl = "#7B7D7D",
                             upl = "#7B7D7D",
-                            target = "#361475",
-                            trajectory = "#de1b1b") {
+                            target = "#de1b1b",
+                            trajectory = "#361475") {
   structure(
     list(
       common_cause              = common_cause,

--- a/man/ptd_spc_colours.Rd
+++ b/man/ptd_spc_colours.Rd
@@ -12,8 +12,8 @@ ptd_spc_colours(
   mean_line = "#000000",
   lpl = "#7B7D7D",
   upl = "#7B7D7D",
-  target = "#361475",
-  trajectory = "#de1b1b"
+  target = "#de1b1b",
+  trajectory = "#361475"
 )
 }
 \arguments{

--- a/tests/testthat/test-ptd_spc.R
+++ b/tests/testthat/test-ptd_spc.R
@@ -184,8 +184,15 @@ test_that("it accepts nse arguments as well as string", {
   stub(ptd_spc, "to_datetime", function(x, ...) x)
 
   s1 <- ptd_spc(data, vf, df)
-  s2 <- ptd_spc(data, value_field = vf, date_field = df, facet_field = ff, rebase = ptd_rebase(), target = ta,
-                trajectory = tr)
+  s2 <- ptd_spc(
+    data,
+    value_field = vf, 
+    date_field = df, 
+    facet_field = ff, 
+    rebase = ptd_rebase(), 
+    target = ta,
+    trajectory = tr
+  )
 
   expect_called(m, 2)
   expect_args(m, 1, "vf", "df", NULL, NULL, NULL, "increase", NULL, NULL)


### PR DESCRIPTION
- [X] added unit tests and checked code coverage with `covr::report()` (should aim for 100%)
- [X] ran `devtools::document()`
- [X] ran `lintr::lint_package()` and resolved all lint warnings and notes
- [X] ran `styler::style_pkg()` to make sure code matches the style guidelines
- [X] ran R-CMD CHECK and resolved all issues

Fixes #84 
The target line is now red, and the trajectory line is purple.  
