### PR TITLE
minor change to test, mocks the call to ptd_calculate_assurance_type

### DIFF
--- a/tests/testthat/test-ptd_spc.R
+++ b/tests/testthat/test-ptd_spc.R
@@ -295,8 +295,6 @@ test_that("it outputs expected content", {
 
   d$facet <- rep(c(0, 1), each = 10)
 
-  d$target <- 1
-
   stub(ptd_spc, "ptd_assurance_type", "assurance_type")
 
   s1 <- ptd_spc(d, "y", "x")
@@ -315,6 +313,10 @@ test_that("it outputs expected content", {
   )
   expect_snapshot_output(summary(s4))
 
+  m <- mock(tibble(f = "no facet", assurance_type = "a"))
+  stub(summary.ptd_spc_df, "ptd_calculate_assurance_type", m)
+
   s5 <- ptd_spc(d, "y", "x", target = 0.5)
   expect_snapshot_output(summary(s5))
+  expect_called(m, 1)
 })


### PR DESCRIPTION
- [x] added unit tests and checked code coverage with `covr::report()` (should aim for 100%)
- [x] ran `devtools::document()`
- [x] ran `lintr::lint_package()` and resolved all lint warnings and notes
- [x] ran `styler::style_pkg()` to make sure code matches the style guidelines
- [x] ran R-CMD CHECK and resolved all issues
