### PR TITLE
Create action for Readme.Rmd

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@
 ^CODE_OF_CONDUCT\.md$
 
 ^coverage.xml$
+^pre-commit.sh$

--- a/.github/workflows/run-pre-commit-hooks.yaml
+++ b/.github/workflows/run-pre-commit-hooks.yaml
@@ -1,0 +1,14 @@
+on: [pull_request]
+
+name: Run Pre-Commit Hooks
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Run Pre Commit Hooks"
+        run: ./pre-commit.sh
+        

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+README=($(git diff --cached --name-only | grep -Ei '^README\.[R]?md$'))
+MSG="use 'git commit --no-verify' to override this check"
+
+if [[ ${#README[@]} == 0 ]]; then
+  exit 0
+fi
+
+if [[ README.Rmd -nt README.md ]]; then
+  echo -e "README.md is out of date; please re-knit README.Rmd\n$MSG"
+  exit 1
+elif [[ ${#README[@]} -lt 2 ]]; then
+  echo -e "README.Rmd and README.md should be both staged\n$MSG"
+  exit 1
+fi


### PR DESCRIPTION
Fixes #160. Adds an action that runs a pre-commit hook to check that the
Readme.Rmd has been re-rendered after changes
