### PR TITLE
Use {scales}'s built-in accuracy heuristic (instead of supplied y_axis_breaks) to set y-axis label formatting

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,9 +2,12 @@ linters: linters_with_defaults(
   line_length_linter(120),
   cyclocomp_linter(23),
   indentation_linter(hanging_indent_style = "tidy"),
-  object_name_linter("snake_case"))
+  object_name_linter("snake_case"),
+  trailing_blank_lines_linter = NULL
+  )
 exclusions: list(
-  "R/ptd_spc_colours.R" = 5)
+  "R/ptd_spc_colours.R" = 5
+  )
 exclude: "# Exclude Linting|#\\s?nolint"
 exclude_start: "# Begin Exclude Linting|#\\s?nolint-start"
 exclude_end: "# End Exclude Linting|#\\s?nolint-end"

--- a/.lintr
+++ b/.lintr
@@ -11,4 +11,4 @@ exclusions: list(
 exclude: "# Exclude Linting|#\\s?nolint"
 exclude_start: "# Begin Exclude Linting|#\\s?nolint-start"
 exclude_end: "# End Exclude Linting|#\\s?nolint-end"
-encoding: "ISO-8859-1"
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,15 @@ Authors@R: c(
           person("Chris", "Mainey", ,"c.mainey@nhs.net", "aut", comment = c(ORCID ="0000-0002-3018-6171")),
           person("John", "MacKintosh", ,"john.mackintosh3@nhs.scot", "aut"),
           person("Marcos", "Fabietti", ,"marcos.fabietti@nuh.nhs.uk", "aut"),
-          person("NHS-R community", email = "nhs.rcommunity@nhs.net", role = "cph")
+        person("Fran", "Barton",
+            email = "francis.barton@nhs.net",
+            role = "aut",
+            comment = c(ORCID = "0000-0002-5650-1176")
+        ),
+        person("NHS-R community",
+            email = "nhs.rcommunity@nhs.net",
+            role = "cph"
+        )
           )
 Maintainer: Christopher Reading <christopher.reading1@nhs.net>
 Description: Provides tools for drawing Statistical Process Control (SPC) charts. This package supports the NHSE/I

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,26 +11,24 @@ Authors@R: c(
           person("Chris", "Mainey", ,"c.mainey@nhs.net", "aut", comment = c(ORCID ="0000-0002-3018-6171")),
           person("John", "MacKintosh", ,"john.mackintosh3@nhs.scot", "aut"),
           person("Marcos", "Fabietti", ,"marcos.fabietti@nuh.nhs.uk", "aut"),
-        person("Fran", "Barton",
+          person("Fran", "Barton",
             email = "francis.barton@nhs.net",
             role = "aut",
             comment = c(ORCID = "0000-0002-5650-1176")
-        ),
-        person("NHS-R community",
+          ),
+          person("NHS-R community",
             email = "nhs.rcommunity@nhs.net",
             role = "cph"
-        )
           )
+        )
 Maintainer: Christopher Reading <christopher.reading1@nhs.net>
-Description: Provides tools for drawing Statistical Process Control (SPC) charts. This package supports the NHSE/I
-  programme 'Making Data Count', and allows users to draw XmR charts, use change points and apply rules with summary
-  indicators for when rules are breached.
+Description: Provides tools for drawing Statistical Process Control (SPC) charts. This package supports the NHSE/I programme 'Making Data Count', and allows users to draw XmR charts, use change points and apply rules with summary indicators for when rules are breached.
 URL: https://nhs-r-community.github.io/NHSRplotthedots,
     https://github.com/nhs-r-community/NHSRplotthedots
 BugReports: https://nhs-r-community.github.io/NHSRplotthedots/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 Imports: 
     assertthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,15 +3,15 @@ Type: Package
 Title: Draw XmR Charts for NHSE/I 'Making Data Count' Programme
 Version: 0.1.0.9000
 Authors@R: c(
-          person("Christopher", "Reading", ,"christopher.reading1@nhs.net", c("cre", "aut")),
-          person("Simon", "Wellesley-Miller", ,"simon.wellesley-miller@nhs.net", "aut"),
-          person("Zoë", "Turner", , "Zoe.Turner2@nottshc.nhs.uk", "aut", comment = c(ORCID = "0000-0003-1033-9158")),
-          person("Tom", "Jemmett", ,"thomas.jemmett@nhs.net", "aut", comment = c(ORCID="0000-0002-6943-2990")),
-          person("Tom", "Smith", ,"thomas.smith5@nuh.nhs.uk", "aut"),
-          person("Chris", "Mainey", ,"c.mainey@nhs.net", "aut", comment = c(ORCID ="0000-0002-3018-6171")),
-          person("John", "MacKintosh", ,"john.mackintosh3@nhs.scot", "aut"),
-          person("Marcos", "Fabietti", ,"marcos.fabietti@nuh.nhs.uk", "aut"),
-          person("Fran", "Barton",
+        person("Christopher", "Reading", ,"christopher.reading1@nhs.net", c("cre", "aut")),
+        person("Simon", "Wellesley-Miller", ,"simon.wellesley-miller@nhs.net", "aut"),
+        person("Zoë", "Turner", , "Zoe.Turner2@nottshc.nhs.uk", "aut", comment = c(ORCID = "0000-0003-1033-9158")),
+        person("Tom", "Jemmett", ,"thomas.jemmett@nhs.net", "aut", comment = c(ORCID="0000-0002-6943-2990")),
+        person("Tom", "Smith", ,"thomas.smith5@nuh.nhs.uk", "aut"),
+        person("Chris", "Mainey", ,"c.mainey@nhs.net", "aut", comment = c(ORCID ="0000-0002-3018-6171")),
+        person("John", "MacKintosh", ,"john.mackintosh3@nhs.scot", "aut"),
+        person("Marcos", "Fabietti", ,"marcos.fabietti@nuh.nhs.uk", "aut"),
+        person("Fran", "Barton",
             email = "francis.barton@nhs.net",
             role = "aut",
             comment = c(ORCID = "0000-0002-5650-1176")
@@ -61,4 +61,4 @@ Suggests:
 Depends: R (>= 4.1.0)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-Language: en-US
+Language: en-GB

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -305,7 +305,7 @@ ptd_create_ggplot <- function(
           breaks = y_axis_labels,
           labels = scales::label_percent(),
           sec.axis = ggplot2::sec_axis(
-            trans = identity,
+            transform = identity,
             name = NULL,
             breaks = sec_breaks,
             labels = scales::label_percent(accuracy = 0.1)
@@ -326,7 +326,7 @@ ptd_create_ggplot <- function(
         breaks = y_axis_labels,
         labels = scales::label_number(),
           sec.axis = ggplot2::sec_axis(
-            trans = identity,
+          transform = identity,
             name = NULL,
             breaks = sec_breaks,
           labels = scales::label_number()

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -252,52 +252,7 @@ ptd_create_ggplot <- function(
     y_axis_labels <- ggplot2::waiver()
   }
 
-  # Nested combinations of 3 binary options = 2^3 (8) possible plot designs
   if (percentage_y_axis) {
-    # Where we have y_axis_breaks specified, we then use y_axis_labels as
-    # the breaks argument to scale_y_continuous()
-    if (!is.null(y_axis_breaks)) {
-      if (label_limits) {
-        # %age axes + specified breaks + sec labelling axis
-        plot <- plot +
-          ggplot2::scale_y_continuous(
-            breaks = y_axis_labels,
-            labels = scales::label_percent(accuracy = y_axis_breaks),
-            sec.axis = ggplot2::sec_axis(
-              trans = identity,
-              name = NULL,
-              breaks = sec_breaks,
-              labels = scales::label_percent(accuracy = y_axis_breaks)
-            )
-          )
-      } else {
-        # %age axes + specified breaks - no sec labelling axis
-        plot <- plot +
-          ggplot2::scale_y_continuous(
-            breaks = y_axis_labels,
-            labels = scales::label_percent(accuracy = y_axis_breaks)
-          )
-      }
-    } else if (label_limits) {
-      # %age axes + sec labelling axis - no specified breaks
-      plot <- plot +
-        ggplot2::scale_y_continuous(
-          labels = scales::label_percent(accuracy = y_axis_breaks),
-          sec.axis = ggplot2::sec_axis(
-            trans = identity,
-            name = NULL,
-            breaks = sec_breaks,
-            labels = scales::label_percent(accuracy = y_axis_breaks)
-          )
-        )
-    } else {
-      # %age axes - no specified breaks - no sec labelling axis
-      plot <- plot +
-        ggplot2::scale_y_continuous(
-          labels = scales::label_percent(accuracy = y_axis_breaks)
-        )
-    }
-  } else if (!is.null(y_axis_breaks)) {
     if (label_limits) {
       # percentage y-axis, secondary labelling axis
       plot <- plot +
@@ -321,25 +276,24 @@ ptd_create_ggplot <- function(
     }
   } else if (label_limits) {
     # integer y-axis, secondary labelling axis
-      plot <- plot +
-        ggplot2::scale_y_continuous(
+    plot <- plot +
+      ggplot2::scale_y_continuous(
         breaks = y_axis_labels,
         labels = scales::label_number(),
-          sec.axis = ggplot2::sec_axis(
+        sec.axis = ggplot2::sec_axis(
           transform = identity,
-            name = NULL,
-            breaks = sec_breaks,
+          name = NULL,
+          breaks = sec_breaks,
           labels = scales::label_number()
-          )
         )
-    } else {
+      )
+  } else {
     # integer y-axis, no secondary axis
-      plot <- plot +
-        ggplot2::scale_y_continuous(
+    plot <- plot +
+      ggplot2::scale_y_continuous(
         breaks = y_axis_labels, # Here this just means use `waiver()`
         labels = scales::label_number()
-        )
-    }
+      )
   }
 
 

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -252,6 +252,8 @@ ptd_create_ggplot <- function(
 
   # Nested combinations of 3 binary options = 2^3 (8) possible plot designs
   if (percentage_y_axis) {
+    # Where we have y_axis_breaks specified, we then use y_axis_labels as
+    # the breaks argument to scale_y_continuous()
     if (!is.null(y_axis_breaks)) {
       if (label_limits) {
         # %age axes + specified breaks + sec labelling axis

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -238,7 +238,7 @@ ptd_create_ggplot <- function(
   sec_breaks <- .data |>
     # should already be sorted in date order but just in case
     dplyr::arrange(x) |>
-    dplyr::select(all_of(c("lpl", "mean_col", "upl"))) |>
+    dplyr::select(c("lpl", "mean_col", "upl")) |>
     dplyr::slice_tail(n = 1) |>
     unlist() |>
     unname()

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -248,6 +248,8 @@ ptd_create_ggplot <- function(
     start <- floor(min(yaxis, na.rm = TRUE) / y_axis_breaks) * y_axis_breaks
     end <- max(yaxis, na.rm = TRUE)
     y_axis_labels <- seq(from = start, to = end, by = y_axis_breaks)
+  } else {
+    y_axis_labels <- ggplot2::waiver()
   }
 
   # Nested combinations of 3 binary options = 2^3 (8) possible plot designs
@@ -297,44 +299,45 @@ ptd_create_ggplot <- function(
     }
   } else if (!is.null(y_axis_breaks)) {
     if (label_limits) {
-      # integer axes + specified breaks + sec labelling axis
+      # percentage y-axis, secondary labelling axis
       plot <- plot +
         ggplot2::scale_y_continuous(
           breaks = y_axis_labels,
-          labels = scales::label_number(accuracy = y_axis_breaks),
+          labels = scales::label_percent(),
           sec.axis = ggplot2::sec_axis(
             trans = identity,
             name = NULL,
             breaks = sec_breaks,
-            labels = scales::label_number(accuracy = 0.01)
+            labels = scales::label_percent(accuracy = 0.1)
           )
         )
     } else {
-      # integer axes + specified breaks - no sec labelling axis
+      # percentage y-axis, no secondary labelling axis
       plot <- plot +
         ggplot2::scale_y_continuous(
-          breaks = y_axis_labels,
-          labels = scales::label_number(accuracy = y_axis_breaks)
+          breaks = y_axis_labels, # Here this just means use `waiver()`
+          labels = scales::label_percent()
         )
     }
-  } else {
-    if (label_limits) {
-      # integer axes + sec labelling axis - no specified breaks
+  } else if (label_limits) {
+    # integer y-axis, secondary labelling axis
       plot <- plot +
         ggplot2::scale_y_continuous(
-          labels = scales::label_number(accuracy = y_axis_breaks),
+        breaks = y_axis_labels,
+        labels = scales::label_number(),
           sec.axis = ggplot2::sec_axis(
             trans = identity,
             name = NULL,
             breaks = sec_breaks,
-            labels = scales::label_number(accuracy = 0.01)
+          labels = scales::label_number()
           )
         )
     } else {
-      # integer axes - no specified breaks - no sec labelling axis
+    # integer y-axis, no secondary axis
       plot <- plot +
         ggplot2::scale_y_continuous(
-          labels = scales::label_number(accuracy = y_axis_breaks)
+        breaks = y_axis_labels, # Here this just means use `waiver()`
+        labels = scales::label_number()
         )
     }
   }

--- a/R/ptd_create_ggplot.R
+++ b/R/ptd_create_ggplot.R
@@ -249,6 +249,7 @@ ptd_create_ggplot <- function(
     end <- max(yaxis, na.rm = TRUE)
     y_axis_labels <- seq(from = start, to = end, by = y_axis_breaks)
   } else {
+    # if no y-axis breaks supplied by user, we just use the built-in heuristic
     y_axis_labels <- ggplot2::waiver()
   }
 
@@ -257,7 +258,7 @@ ptd_create_ggplot <- function(
       # percentage y-axis, secondary labelling axis
       plot <- plot +
         ggplot2::scale_y_continuous(
-          breaks = y_axis_labels,
+          breaks = y_axis_labels, # see above - can mean "just use waiver()"
           labels = scales::label_percent(),
           sec.axis = ggplot2::sec_axis(
             transform = identity,
@@ -270,7 +271,7 @@ ptd_create_ggplot <- function(
       # percentage y-axis, no secondary labelling axis
       plot <- plot +
         ggplot2::scale_y_continuous(
-          breaks = y_axis_labels, # Here this just means use `waiver()`
+          breaks = y_axis_labels,
           labels = scales::label_percent()
         )
     }
@@ -291,7 +292,7 @@ ptd_create_ggplot <- function(
     # integer y-axis, no secondary axis
     plot <- plot +
       ggplot2::scale_y_continuous(
-        breaks = y_axis_labels, # Here this just means use `waiver()`
+        breaks = y_axis_labels,
         labels = scales::label_number()
       )
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ Please be aware that this package is in the early stages of development, and fea
 
 ## Installation
 
-```{r, eval=FALSE}
+```r
 # install from CRAN
 install.packages("NHSRplotthedots")
 
@@ -44,33 +44,38 @@ remotes::install_github("https://github.com/nhs-r-community/NHSRplotthedots", bu
 
 # Overview
 
-Welcome to the NHS-R community's package for building a specific type of statistical process control (SPC) chart, the
-XmR chart. We are aiming to support NHS England's ['Making Data Count'][mdc] programme. The programme encourages boards,
-managers, and analyst teams to present data in ways that show change over time and drive better understanding of
-indicators than 'RAG' (red, amber, green) rated board reports often present.
+Welcome to the NHS-R community's package for building a specific type of statistical process control (SPC) chart, the XmR chart.
+  We are aiming to support NHS England's ['Making Data Count'][mdc] programme.
+  The programme encourages boards, managers, and analyst teams to present data in ways that show change over time and drive better understanding of indicators than 'RAG' (red, amber, green) rated board reports often present.
 
-The help files and vignettes within this package tell you more about the possible options for controlling the charts,
-but below is a simple example of the type of chart the package produces.  We will use the `ae_attendances` dataset from
-the `{NHSRdatasets}` package and a bit of  `{dplyr}` code to select some organisations.
+The help files and vignettes within this package tell you more about the possible options for controlling the charts, but below are some simple examples of the type of chart the package produces.
+  We will use the `ae_attendances` dataset from the `{NHSRdatasets}` package and a bit of `{dplyr}` code to select some organisations.
 
 ```{r example, message=FALSE, warning=FALSE}
 library(NHSRplotthedots)
 library(NHSRdatasets)
-library(tidyverse)
+library(dplyr)
 
 sub_set <- ae_attendances %>%
   filter(org_code == "RQM", type == 1, period < as.Date("2018-04-01"))
 
 sub_set %>%
-  ptd_spc(value_field = breaches, date_field = period, improvement_direction = "decrease")
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease"
+  )
 ```  
 
-This plot is ok on its own, but we can specify more control options when we pass it on, using the `{dplyr}` pipe
-function below: `%>%` to the plot argument.
+This plot is ok on its own, but we can specify more control options if we explicitly pass it on to the `plot()` function.
 
 ```{r}
 sub_set %>%
-  ptd_spc(value_field = breaches, date_field = period, improvement_direction = "decrease") %>%
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease"
+  ) %>%
   plot(
     y_axis_label = "4-hour wait breaches",
     main_title = "SPC of A&E waiting time breaches for RQM"
@@ -79,25 +84,35 @@ sub_set %>%
 
 or, equivalently:
 
-```{r, eval=FALSE}
+```r
 sub_set %>%
-  ptd_spc(value_field = breaches, date_field = period, improvement_direction = "decrease") %>%
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease"
+  ) %>%
   ptd_create_ggplot(
     y_axis_label = "4-hour wait breaches",
     main_title = "SPC of A&E waiting time breaches for RQM"
   )
 ```
-In addition, you can use summary() function to get some basic statistics about your SPC data frame.
+You can also use the `summary()` function to get some basic statistics about your SPC data frame.
 The function prints the SPC options, and then returns the summarised results as a table:
-```{r, eval=TRUE}
+
+```r
 summary <- sub_set %>%
-  ptd_spc(value_field = breaches, date_field = period, improvement_direction = "decrease", target = 1200) %>%
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease",
+    target = 1200
+  ) %>%
   summary()
 ```
 
 You could assign this summary table to a variable and use it later:
 
-```{r, eval=TRUE}
+```r
 summary$variation_type
 summary$assurance_type
 ```
@@ -105,35 +120,65 @@ summary$assurance_type
 
 ### Interactive plots with Plotly
 
-It's also possible to generate interactive plots using the `{plotly}` package by replacing the call to `plot` with
-`ptd_create_plotly`. This function takes the same arguments as `plot`/`ptd_create_ggplot`.
+It's also possible to generate interactive plots using the `{plotly}` package by replacing the call to `plot` with `ptd_create_plotly`.
+    This function takes the same arguments as `plot`/`ptd_create_ggplot`.
 
-```{r, eval=FALSE}
+```r
 sub_set %>%
-  ptd_spc(value_field = breaches, date_field = period, improvement_direction = "decrease") %>%
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease"
+  ) %>%
   ptd_create_plotly(
     y_axis_label = "4-hour wait breaches",
     main_title = "SPC of A&E waiting time breaches for RQM"
   )
 ```
 
+
+### Adding annotations for mean and process limits
+
+The package (from v0.2.0) supports annotating the values of the mean and the
+  upper and lower process limits on a secondary (right-hand side) y axis,
+  if this is helpful for you and your audience.
+
+The way to achieve this is to turn on the `label_limits` option:
+
+```{r}
+sub_set |>
+  ptd_spc(
+    value_field = breaches,
+    date_field = period,
+    improvement_direction = "decrease"
+  ) |>
+  ptd_create_ggplot(
+    y_axis_label = "4-hour wait breaches",
+    main_title = "SPC of A&E waiting time breaches for RQM",
+    label_limits = TRUE
+  )
+```
+
+If you have rebased the chart, the mean and process limit annotations will only show for the most recent section.
+
+
 ## Getting help
 
 To find out more about the `ptd_spc()` function, you can view the help with:
 
-```{r, eval=FALSE}
+```r
 ?ptd_spc
 ```
 
 Details on the extra plot controls can be found using:
 
-```{r, eval=FALSE}
+```r
 ?ptd_create_ggplot
 ```
 
 To view the vignette (worked example), use:
 
-```{r eval=FALSE}
+```r
 vignette("intro", package = "NHSRplotthedots")
 
 vignette(package = "NHSRplotthedots")
@@ -141,17 +186,18 @@ vignette(package = "NHSRplotthedots")
 
 # Contribution
 
-This is an NHS-R Community project that is open for anyone to contribute to in any way that they are able. The project 
-is released with a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). By
-contributing to this project, you agree to abide by its terms.
+This is an NHS-R Community project that is open for anyone to contribute to in any way that they are able.
+  The project is released with a [Contributor Code of Conduct][coc].
+  By contributing to this project, you agree to abide by its terms.
 
-If you want to learn more about this project, please join the discussion at [the NHS-R Community Slack group][nhsr-slack]
-and the specific channel [#proj-nhsr-plot-the-dots][#proj-nhsr-plot-the-dots]. 
+If you want to learn more about this project, please join the discussion at
+  [the NHS-R Community Slack group][nhsr-slack] and the specific channel 
+  [#proj-nhsr-plot-the-dots][ptd-slack-channel]. 
 
-The simplest way to contribute is to raise an issue detailing the feature or functionality you would like to see added,
-or any unexpected behaviour or bugs you have experienced.  
+The simplest way to contribute is to raise an issue detailing the feature or functionality you would like to see added, or any unexpected behaviour or bugs you have experienced.
 
 [nhsr]: https://nhsrcommunity.com
 [mdc]: https://www.england.nhs.uk/publication/making-data-count/
+[coc]: https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html
 [nhsr-slack]: https://nhsrcommunity.slack.com/
-[#proj-nhsr-plot-the-dots]: https://nhsrcommunity.slack.com/archives/CSVD4SYF3
+[ptd-slack-channel]: https://nhsrcommunity.slack.com/archives/CSVD4SYF3

--- a/inst/hex-logo.R
+++ b/inst/hex-logo.R
@@ -191,8 +191,7 @@ simple_pointplot <- function(
   # create the subplot: points and line
   subplot <- demo_data_tb %>%
     ggplot2::ggplot(ggplot2::aes(x, y)) +
-    ggplot2::geom_line(size = line_size,
-                       colour = line_colour) +
+    ggplot2::geom_line(size = line_size, colour = line_colour) +
     ggplot2::geom_point(
       aes(fill = fill),
       size = point_size,
@@ -202,9 +201,7 @@ simple_pointplot <- function(
     ) +
     ggplot2::scale_fill_manual(values = fill_palette) +
     ggplot2::theme_void() + # remove all the features, except the main plot
-    ggplot2::theme( # remove the legend
-      legend.position = "none"
-    ) +
+    ggplot2::theme(legend.position = "none") + # remove the legend
     hexSticker::theme_transparent() # make background of the plot transparent
   subplot
 }
@@ -212,12 +209,12 @@ simple_pointplot <- function(
 # Community designed logo ----
 # Based on the design provided by an user on Twitter, this is an "approximated"
 # version created with R
-fill_palette <-
-  c(orange = "#eb7f3c", # orange
-    nhs_dark_grey = "#425563", # NHS Dark grey
-    nhs_dark_blue = "#005eb8") # NHS blue
-fill_palette_breaks <-
-  seq(.2, .8, length.out = length(fill_palette) - 1) * 6
+fill_palette <- c(
+  orange = "#eb7f3c", # orange
+  nhs_dark_grey = "#425563", # NHS Dark grey
+  nhs_dark_blue = "#005eb8" # NHS blue
+)
+fill_palette_breaks <- seq(.2, .8, length.out = length(fill_palette) - 1) * 6
 line_size <- .75
 line_colour <- fill_palette["nhs_dark_grey"]
 point_size <- 3.5
@@ -237,40 +234,48 @@ demo_data_tb <- data.frame(
 # create the subplot: points and line
 subplot <- demo_data_tb %>%
   ggplot2::ggplot(aes(x, y)) +
-  ggplot2::geom_line(size = line_size,
-                     colour = line_colour) +
-  ggplot2::geom_point(aes(fill = fill),
-                      size = point_size,
-                      shape = point_shape,
-                      stroke = point_stroke) +
-  ggplot2::annotate(geom = "text",
-                    x = -0.5,
-                    y = 4,
-                    label = "making\ndata\ncount\nin\nthe",
-                    colour = line_colour,
-                    size = 13,
-                    fontface = "bold",
-                    lineheight = .2,
-                    hjust = 0) +
-  ggplot2::annotate(geom = "text",
-                    x = -0.5,
-                    y = 2.2,
-                    label = "NHS",
-                    colour = fill_palette["nhs_dark_blue"], # NHS Blue
-                    size = 16,
-                    fontface = "bold",
-                    lineheight = .2,
-                    hjust = 0) +
+  ggplot2::geom_line(size = line_size, colour = line_colour) +
+  ggplot2::geom_point(
+    aes(fill = fill),
+    size = point_size,
+    shape = point_shape,
+    stroke = point_stroke
+  ) +
+  ggplot2::annotate(
+    geom = "text",
+    x = -0.5,
+    y = 4,
+    label = "making\ndata\ncount\nin\nthe",
+    colour = line_colour,
+    size = 13,
+    fontface = "bold",
+    lineheight = .2,
+    hjust = 0
+  ) +
+  ggplot2::annotate(
+    geom = "text",
+    x = -0.5,
+    y = 2.2,
+    label = "NHS",
+    colour = fill_palette["nhs_dark_blue"], # NHS Blue
+    size = 16,
+    fontface = "bold",
+    lineheight = .2,
+    hjust = 0
+  ) +
   ggplot2::scale_fill_manual(values = unname(fill_palette)) +
   ggplot2::theme_void() + # remove all the features, except the main plot
-  ggplot2::theme( # remove the legend
+  # remove the legend
+  ggplot2::theme(
     legend.position = "none",
     text = ggplot2::element_text(family = font_family)
   ) +
   hexSticker::theme_transparent() # make background of the plot transparent
 
-hex_logo(subplot,
-         main_colour = line_colour,
-         url = "",
-         p_family = font_family,
-         out_filename = "inst/images/logo.png")
+hex_logo(
+  subplot,
+  main_colour = line_colour,
+  url = "",
+  p_family = font_family,
+  out_filename = "inst/images/logo.png"
+)

--- a/man/NHSRplotthedots-package.Rd
+++ b/man/NHSRplotthedots-package.Rd
@@ -29,6 +29,7 @@ Authors:
   \item Chris Mainey \email{c.mainey@nhs.net} (\href{https://orcid.org/0000-0002-3018-6171}{ORCID})
   \item John MacKintosh \email{john.mackintosh3@nhs.scot}
   \item Marcos Fabietti \email{marcos.fabietti@nuh.nhs.uk}
+  \item Fran Barton \email{francis.barton@nhs.net} (\href{https://orcid.org/0000-0002-5650-1176}{ORCID})
 }
 
 Other contributors:

--- a/tests/testthat/test-ptd_create_ggplot.R
+++ b/tests/testthat/test-ptd_create_ggplot.R
@@ -323,13 +323,10 @@ test_that("it sets the colour of the points based on the type", {
   stub(ptd_create_ggplot, "ggplot2::scale_colour_manual", m)
 
   set.seed(123)
-  d <- data.frame(x = as.Date("2020-01-01") + 1:20, y = rnorm(20)) |>
+  d <- data.frame(x = as.Date("2020-01-01") + seq(20L), y = rnorm(20L)) |>
     # introduce some special cause variation!
     dplyr::mutate(
-      across("y", \(y) dplyr::case_when(
-        x > "2020-01-15" ~ y + 0.5,
-        TRUE ~ y
-      ))
+      across("y", \(y) dplyr::if_else(.data[["x"]] > "2020-01-15", y + 0.5, y))
     )
 
   colours_neutral <- list(

--- a/tests/testthat/test-ptd_create_ggplot.R
+++ b/tests/testthat/test-ptd_create_ggplot.R
@@ -252,8 +252,8 @@ test_that("it sets the y-axis to percentages if percentage_y_axis is TRUE", {
   p2 <- ptd_create_ggplot(s, percentage_y_axis = TRUE, y_axis_breaks = 0.2)
 
   expect_called(m, 2)
-  expect_args(m, 1, accuracy = NULL)
-  expect_args(m, 2, accuracy = 0.2)
+  # expect_args(m, 1, accuracy = NULL) # test no longer useful after issue #210
+  # expect_args(m, 2, accuracy = 0.2) # test no longer useful after issue #210
 })
 
 test_that("it sets the y-axis if y_axis_breaks is provided", {

--- a/tests/testthat/test-ptd_create_ggplot.R
+++ b/tests/testthat/test-ptd_create_ggplot.R
@@ -239,23 +239,6 @@ test_that("it creates a secondary y axis with integer scales", {
   expect_equal(p2$scales$scales[[3]]$secondary.axis$breaks, sec_breaks)
 })
 
-test_that("it sets the y-axis to percentages if percentage_y_axis is TRUE", {
-  set.seed(123)
-
-  m <- mock()
-  stub(ptd_create_ggplot, "scales::label_percent", m)
-
-  d <- data.frame(x = as.Date("2020-01-01") + 1:20, y = rnorm(20))
-  s <- ptd_spc(d, "y", "x")
-
-  p1 <- ptd_create_ggplot(s, percentage_y_axis = TRUE)
-  p2 <- ptd_create_ggplot(s, percentage_y_axis = TRUE, y_axis_breaks = 0.2)
-
-  expect_called(m, 2)
-  # expect_args(m, 1, accuracy = NULL) # test no longer useful after issue #210
-  # expect_args(m, 2, accuracy = 0.2) # test no longer useful after issue #210
-})
-
 test_that("it sets the y-axis if y_axis_breaks is provided", {
   set.seed(123)
   d <- data.frame(x = as.Date("2020-01-01") + 1:20, y = rnorm(20))

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -19,42 +19,39 @@ library(NHSRplotthedots)
 library(NHSRdatasets)
 ```
 
-The overall intent of this package is to mimic as completely as possible the output available from the
-[NHSEI Making Data Count][mdc] Excel tools. However, we have identified some areas where the R implementation 
-should deviate from the main Excel tools. We have done this only after careful consideration, and we believe there is a 
-benefit to deviating.
+The overall intent of this package is to mimic as completely as possible the output available from the [NHSEI Making Data Count][mdc] Excel tools.
+However, we have identified some areas where the R implementation should deviate from the main Excel tools.
+We have done this only after careful consideration, and we believe there is a benefit to deviating.
 
-This vignette documents what these differences are, and how to 
-set options to over-ride them, so that if you need to you can completely replicate the output that the Excel tools would create.  
+This vignette documents what these differences are, and how to set options to over-ride them, so that if you need to you can completely replicate the output that the Excel tools would create.
 
-You may consider this important if for example you are publishing outputs from both the Excel tool and this R tool, and 
-need the outputs to be completely consistent.
+You may consider this important if for example you are publishing outputs from both the Excel tool and this R tool, and need the outputs to be completely consistent.
 
 ## List of Deviations
 
 ### 1. Treatment of outlying points
 
-By default, this package will screen outlying points, removing them from the moving range calculation, and hence from 
-the process limits calculation. This is in line with the published paper:
+By default, this package will screen outlying points, removing them from the moving range calculation, and hence from the process limits calculation.
+This is in line with the published paper:
 
-> Nelson, LS, "Control Charts for Individual Measurements", Journal of Quality Technology, 1982, 14(34)
+> Nelson, Lloyd S. (1982) Control Charts for Individual Measurements, _Journal of Quality Technology_ 14(3): 172-173
 
 It is discussed further in the book:
 
-> Lloyd P Provost & Sandra K Murray, The Health Care Data Guide: Learning from Data for Improvement (San Francisco, CA: Jossey-Bass, 2011), p.155 & p.192.
+> Provost, Lloyd P. & Murray, Sandra K. (2011) _The Health Care Data Guide: Learning from Data for Improvement_, San Francisco, CA: Jossey-Bass, pp.155, 192
 
 
-The Making Data Count" Excel tools do not screen outlying points, and all points are included in the moving range and
-limits calculations. If outlying points exist, the process limits on the Excel tools will therefore be wider than if
-outlying points were screened from the calculation.
+The "Making Data Count" Excel tools do not screen outlying points, and all points are included in the moving range and limits calculations.
+If outlying points exist, the process limits on the Excel tools will therefore be wider than if outlying points were screened from the calculation.
 
-This behaviour is controlled by the `screen_outliers` argument. By default, `screen_outliers = TRUE`.  
+This behaviour is controlled by the `screen_outliers` argument.
+By default, `screen_outliers = TRUE`.  
 
 To replicate the Excel method, set the argument `screen_outliers = FALSE`.
 
 The two charts below demonstrate the default, and how to over-ride to replicate the Excel tools.
 
-**R Package Default:**
+#### R Package Default:
 
 ```{r}
 data <- c(1, 2, 1, 2, 10, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)
@@ -74,7 +71,7 @@ spc_data %>%
   )
 ```
 
-**Over-riding to replicate "Making Data Count" Excel output:**
+#### Over-riding to replicate "Making Data Count" Excel output:
 
 ```{r}
 # setting screen_outliers = FALSE produces the same output as Excel
@@ -90,13 +87,16 @@ spc_data %>%
   )
 ```
 
+
 ### 2. Breaking of lines
 
-By default, this package will break process and limit lines when a plot is rebased. The Excel tool draws all lines as
-continuous lines. However, rebasing is a change to the process, so by breaking lines it more clearly indicates that a
-change in process has happened.
+By default, this package will break process and limit lines when a plot is rebased.
+The Excel tool draws all lines as continuous lines.
+However, rebasing is a change to the process, so by breaking lines it more clearly indicates that a change in process has happened.
 
-This can be controlled with the `break_lines` argument. There are 4 possible values:
+This can be controlled with the `break_lines` argument.
+There are 4 possible values:
+
   * "both" (default)
   * "limit" (to just break the limit lines, but leave the process line connected)
   * "process" (to just break the process line, but leave limit lines connected)
@@ -104,7 +104,7 @@ This can be controlled with the `break_lines` argument. There are 4 possible val
 
 Examples of these 4 are shown below:
 
-**R Package Default:**
+#### R Package Default:
 
 ```{r}
 spc_data <- ae_attendances %>%
@@ -115,19 +115,19 @@ spc_data <- ae_attendances %>%
 plot(spc_data, break_lines = "both")
 ```
 
-**just breaking the limit lines:**
+#### Just breaking the limit lines:
 
 ```{r}
 plot(spc_data, break_lines = "limits")
 ```
 
-**just breaking the limit lines:**
+#### Just breaking the process lines:
 
 ```{r}
 plot(spc_data, break_lines = "process")
 ```
 
-**Over-riding to replicate "Making Data Count" Excel output:**
+#### Over-riding to replicate "Making Data Count" Excel output:
 
 ```{r}
 plot(spc_data, break_lines = "none")
@@ -135,26 +135,27 @@ plot(spc_data, break_lines = "none")
 
 ### 3. X Axis Text Angle
 
-As can be seen in the plots above, by default this package will print x axis text rotated by 45 degrees for better utilisation of space, and readability.  Excel's behaviour is to print this text at 90 degrees to the axis. 
+As can be seen in the plots above, by default this package will print x axis text rotated by 45 degrees for better utilisation of space, and readability.
+Excel's behaviour is to print this text at 90 degrees to the axis. 
 
-Text angle can be over-ridden by passing a ggplot `theme()` into the `theme_override` argument of the plot function.  Any of the modifications documented in the [ggplot2 theme documentation](https://ggplot2.tidyverse.org/reference/theme.html) can be made, but in this case we just need to modify `axis.text.x`.
+Text angle can be over-ridden by passing a ggplot `theme()` into the `theme_override` argument of the plot function.
+Any of the modifications documented in the
+    [ggplot2 theme documentation][gg_theme]
+    can be made, but in this case we just need to modify `axis.text.x`.
 
-**To re-instate 90 degree axis text:**
+#### To re-instate 90 degree axis text:
 
 ```{r}
 ae_attendances %>%
   group_by(period) %>%
   summarise(across(attendances, sum)) %>%
   ptd_spc(attendances, period) %>%
-  plot(
-    theme_override = theme(
-      axis.text.x = element_text(angle = 90)
-    )
-  )
+  plot(theme_override = theme(axis.text.x = element_text(angle = 90)))
 ```
 
 ---
-Find the package code on [GitHub](https://github.com/nhs-r-community/NHSRplotthedots)
-
+Find the package code on [GitHub][ptd_gh].
 
 [mdc]: https://www.england.nhs.uk/publication/making-data-count/
+[gg_theme]: https://ggplot2.tidyverse.org/reference/theme.html
+[ptd_gh]: https://github.com/nhs-r-community/NHSRplotthedots

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -6,6 +6,7 @@ vignette: >
  %\VignetteEngine{knitr::rmarkdown}
  %\VignetteEncoding{UTF-8}
 ---
+
 ```{r message=FALSE, warning=FALSE, include=FALSE}
 knitr::opts_chunk$set(
   fig.width = 7, fig.height = 5,
@@ -14,20 +15,20 @@ knitr::opts_chunk$set(
 )
 ```
 
-Welcome to the NHS-R community's collaborative package for building a specific type of statistical process control (SPC)
-chart, the XmR chart. We are aiming to support the NHS England's ['Making Data Count' programme][mdc], a programme which encourages boards, managers, and analyst teams to present data in
-ways that show change over time, and drive better understanding of indicators than 'RAG' (red, amber, green) rated board
-reports often present.
+Welcome to the NHS-R community's collaborative package for building a specific type of statistical process control (SPC) chart, the XmR chart.
+We are aiming to support the NHS England's
+    ['Making Data Count' programme][mdc],
+    a programme which encourages boards, managers, and analyst teams to present
+    data in ways that show change over time, and drive better understanding of
+    indicators than 'RAG' (red, amber, green) rated board reports often support.
 
-This tutorial is a concise take on applying the function to some Accident and Emergency breach data for some NHS
-hospitals. We'll take this from the `NHSRdatasets` package, another of our packages providing example datasets for
-training in an NHS/healthcare context.
+This tutorial is a concise take on applying the function to some Accident and Emergency breach data for some NHS hospitals.
+We'll take this from the `NHSRdatasets` package, another of our packages providing example datasets for training in an NHS/healthcare context.
 
-The analyses below use the `tidyverse` packages: `dplyr` to manipulate the data, and `ggplot2` for plotting (when not
-using `NHSRplotthedots`).
+The analyses below use the `tidyverse` packages: `dplyr` to manipulate the data, and `ggplot2` for plotting (when not using `NHSRplotthedots`).
 
-Firstly, lets load the data, filter for University Hospital Birmingham NHS Foundation Trust, because they are a good
-example for the type of charts below. Let's also do a simple timeseries plot to see why this is the case.
+Firstly, let's load the data, filter for University Hospital Birmingham NHS Foundation Trust, because they are a good example for the type of charts below.
+Let's also do a simple timeseries plot to see why this is the case.
 
 ```{r dataset, message=FALSE, warning=FALSE}
 library(NHSRplotthedots)
@@ -49,15 +50,14 @@ ae_attendances %>%
   theme_minimal()
 ```
 
-This minimal plot shows the changes over time, and we will look at it in two ways. The first, we'll look at 2016/17 &
-2017/18, which is apparently stable and, during 2018, the trust merged with another large 3-hospital provider trust, so
-the numbers through A&E shot up dramatically when combined under one trust code. We can use a change point in our plots
-to consider this.
+This minimal plot shows the changes over time, and we will look at it in two ways.
+The first, we'll look at 2016/17 & 2017/18, which is apparently stable and, during 2018, the trust merged with another large 3-hospital provider trust, so the numbers through A&E shot up dramatically when combined under one trust code.
+We can use a change point in our plots to consider this.
 
-Let's now use the `ptd_spc` function to draw our plot. We need to provide it with a `data.frame` that contains our data,
-and provide a `value_field` for the y-axis, and a `date_field` for the x-axis. Remember to surround the names of the
-columns in the `data.frame` with quotes (making it a string, see below). In addition, to ensure the points are coloured
-correctly, we need to set the `improvement_direction` to "decrease", here (as fewer A&E breaches is better).
+Let's now use the `ptd_spc` function to draw our plot.
+
+We need to provide it with a `data.frame` that contains our data, and provide a `value_field` for the y-axis, and a `date_field` for the x-axis.
+In addition, to ensure the points are coloured correctly, we need to set the `improvement_direction` to "decrease", here (as fewer A&E breaches is better).
 
 ## Stable period
 
@@ -77,18 +77,16 @@ ptd_spc(
 )
 ```
 
-From the chart above, we can see the centre line (mean) and the control limits calculated according the the XmR chart
-rules. Our points that are between the control limits are within control and showing 'common-cause' or 'natural'
-variation. We can see 8 sequential points coloured in blue. This is triggered by a rule that looks for >=7 points on one
-side of the mean. This could be viewed as a period where fewer breaches than average were detected, which may hold some
-learning value for the organisation.
+From the chart above, we can see the centre line (mean) and the control limits calculated according the the XmR chart rules.
+Our points that are between the control limits are within control and showing 'common-cause' or 'natural' variation.
+We can see 8 sequential points coloured in blue. This is triggered by a rule that looks for >=7 points on one side of the mean.
+This could be viewed as a period where fewer breaches than average were detected, which may hold some learning value for the organisation.
 
 ## Change point
 
-From the first plot above, we can see that the change is noticed at 01/07/2019. We understand the reason for the change
-(the merging of two trusts), and believe this will be the new normal range for the process, so it would be valid to
-rebase at this point. To rebase (change the modelling period for control limits), we can pass a vector of dates at the
-point we wish to rebase using the `ptd_rebase()` function.
+From the first plot above, we can see that the change is noticed at 01/07/2019.
+We understand the reason for the change (the merging of two trusts), and believe this will be the new normal range for the process, so it would be valid to rebase at this point.
+To rebase (change the modelling period for control limits), we can pass a vector of dates at the point we wish to rebase using the `ptd_rebase()` function.
 
 ```{r changepoint}
 change_set <- ae_attendances %>%
@@ -106,17 +104,17 @@ You can see that our limit calculation has now shifted at the rebase point.
 
 ## Faceting
 
-In `{ggplot2}`, a `facet` refers to splitting or plotting by variables, into separate plots or regions. Imagine you want
-to do an SPC for all trusts in a dataset, or all specialties at a trust. Facet will help you do this, and you can pass
-the field that controls this to the `ptd_spc` argument `facet_field`.
+In `{ggplot2}`, a `facet` refers to splitting or plotting by variables, into separate plots or regions.
+Imagine you want to do an SPC for all trusts in a dataset, or all specialties at a trust.
+Facet will help you do this, and you can pass the field that controls this to the `ptd_spc` argument `facet_field`.
 
 Here we will pick 6 trusts at random and plot their breaches, faceting across them.
 
-We'll also combine this with a couple more options that are specific to the plot. This is done with the
-`ptd_create_ggplot` function in the backend, but also works with the generic `plot`. To find out the available options,
-see the help-file for: `?ptd_create_ggplot`. We will let the x-axis scale change for each plot for each plot (otherwise
-some would look crushed against a larger trusts) and we will also change the x-axis breaks to 3-months, as 1 month
-looked too busy.)
+We'll also combine this with a couple more options that are specific to the plot.
+This is done with the `ptd_create_ggplot` function in the backend, but also works with the generic `plot`.
+To find out the available options, see the help-file for: `?ptd_create_ggplot`.
+
+We will let the x-axis scale change for each plot for each plot (otherwise some would look crushed against a larger trusts) and we will also change the x-axis breaks to 3-months, as 1 month looked too busy.)
 
 ```{r facetvignette}
 facet_set <- ae_attendances %>%
@@ -136,8 +134,8 @@ ptd_spc(
   plot(fixed_y_axis_multiple = FALSE, x_axis_breaks = "3 months")
 ```
 
-From this, the point-size seems too big, and it would be worth replacing the y-axis title with something better. Again,
-this is done with the `plot` function arguments:
+From this, the point-size seems too big, and it would be worth replacing the y-axis title with something better.
+Again, this is done with the `plot` function arguments:
 
 ```{r facetvignette2}
 facet_set <- ae_attendances %>%
@@ -162,8 +160,7 @@ ptd_spc(
   )
 ```
 
-As the plots are based on `{ggplot2}` you can override elements of the styling and theme as additional arguments using
-`theme`, or by using `theme_override` with your new theme elements in a `list`.
+As the plots are based on `{ggplot2}` you can override elements of the styling and theme as additional arguments using `theme`, or by using `theme_override` with your new theme elements in a `list`.
 
 ```{r facetvignette3}
 facet_set <- ae_attendances %>%
@@ -192,9 +189,10 @@ a + theme(axis.text.x = element_text(size = 6, angle = 45))
 
 ### Interactive plots
 
-It's also possible to create interactive plots using the `{plotly}` package by replacing the call to `plot` with
-`ptd_create_plotly`. This takes the same arguments as `plot` (and `ptd_create_ggplot`). For instance, we can use the
-code from the last example to make an interactive version
+It's also possible to create interactive plots using the `{plotly}` package by replacing the call to `plot` with `ptd_create_plotly`.
+This takes the same arguments as `plot` (and `ptd_create_ggplot`).
+
+For instance, we can use the code from the last example to make an interactive version:
 
 ```{r plotly}
 ptd_spc(
@@ -215,9 +213,11 @@ ptd_spc(
 
 ## Come and join us!
 
-This is a collaborative project that is still early in it's life. All contributors are volunteers, and more volunteers
-would be very welcome (there's even stuff that doesn't require `R` coding to help with!). Find out more at:
-[github.com/nhs-r-community/NHSRplotthedots][nhsrptd_gh]
+This is a collaborative project that is still early in its life.
+All contributors are volunteers, and more volunteers would be very welcome (there's even stuff that doesn't require `R` coding to help with!).
+
+Find out more at:
+[github.com/nhs-r-community/NHSRplotthedots][ptd_gh]
 
 [mdc]: https://www.england.nhs.uk/publication/making-data-count/
-[nhsrptd_gh]: https://github.com/nhs-r-community/NHSRplotthedots
+[ptd_gh]: https://github.com/nhs-r-community/NHSRplotthedots

--- a/vignettes/number-of-points-required.Rmd
+++ b/vignettes/number-of-points-required.Rmd
@@ -26,40 +26,41 @@ Even for the I chart, the experts do not reach a consensus:
 
 **The Health Care Data Guide** (p155) :
 
-"To develop an I chart, the most recent 20 to 30 measurements should be used. More than any other chart, this minimum number of subgroups is important since each subgroup has only one data value".
+> "To develop an I chart, the most recent 20 to 30 measurements should be used. More than any other chart, this minimum number of subgroups is important since each subgroup has only one data value".
 
 **Understanding Variation - The Key to Managing Chaos** (p60):
 
-"Useful limits may be constructed with as few as five or six values"
-
+> "Useful limits may be constructed with as few as five or six values"
 
 **Data Sanity** (First Edition p150): 
 
 Presents a table for runs analysis, starting with 10 data points (and the corresponding lower and upper limit for expected number of runs)
 
-
 Let's throw in one more reference :
 
 **Practical Performance Measurement** (p258)
 
-"We still need a minimum of five consecutive values of a measure just to get started establishing a baseline to represent the current performance level...we might even need more than five to establish that baseline....And once we have our baseline, we need at least another three measure values, and often more than eight, before we can be sure whether performance has changed or not"
+"We still need a minimum of five consecutive values of a measure just to get started establishing a baseline to represent the current performance level... We might even need more than five to establish that baseline...
+And once we have our baseline, we need at least another three measure values, and often more than eight, before we can be sure whether performance has changed or not."
 
 ### I have less than 12 points. What should I do?
 
-If Wheeler say 5 or 6 are good enough, then, as long as you have 5 or 6 points, you can begin to use these charts. However the limits should be considered _useful_, rather than _robust_.
+If Wheeler says 5 or 6 are good enough, then, as long as you have 5 or 6 points, you can begin to use these charts.
+However the limits should be considered _useful_, rather than _robust_.
 
-We  therefore refer to these as 'trial' limits.
+We therefore refer to these as 'trial' limits.
 
 ### What is meant by 'trial limits'?
 
-Just that, due to lack of data , these are as good as they can be, for the time being. With each new data point, the limits will be revised. Once we have enough (i.e. >=12 data points) the calculations will be locked, until such time as a signal of special cause variation occurs - for example, a  long run above or below the mean.
-At this point, if we understand the cause of the variation, we might decide to revise the limits from the start of the long run. Each time the limits are revised, the new limits should be considered 'trial limits' until a further 12 (or more) points are collected, at which point they can be 'locked' once more. 
-
+Just that, due to lack of data, these are as good as they can be, for the time being.
+With each new data point, the limits will be revised.
+Once we have enough (i.e. >=12 data points) the calculations will be locked, until such time as a signal of special cause variation occurs - for example, a long run above or below the mean.
+At this point, if we understand the cause of the variation, we might decide to revise the limits from the start of the long run.
+Each time the limits are revised, the new limits should be considered 'trial limits' until a further 12 (or more) points are collected, at which point they can be 'locked' once more.
 
 ### What does this tool require?
 
-The tool defaults to calculating control limits over the first 12  points for each area or group. 
-
+The tool defaults to calculating control limits over the first 12 points for each area or group.
 
 ### Are there any other charts we can use if we have less than 12 points?
 
@@ -68,7 +69,5 @@ There are alternatives:
 - run charts
 - cumulative sum (cusum) charts
 
-However, the individuals chart is _also_ advised as one of the three "go to" charts when less than 12 data points are available. This package provides a warning for any groups with less than 12 data points, advising that trial limits are in place. 
-
-
-
+However, the individuals chart is _also_ advised as one of the three "go to" charts when less than 12 data points are available.
+This package provides a warning for any groups with less than 12 data points, advising that trial limits are in place.


### PR DESCRIPTION
- [x] added unit tests and checked code coverage with `covr::report()` (should aim for 100%)
- [x] ran `devtools::document()`
- [x] ran `lintr::lint_package()` and resolved all lint warnings and notes
- [x] ran `styler::style_pkg()` to make sure code matches the style guidelines
- [x] ran R-CMD CHECK and resolved all issues

This pull request provides code that simplifies the if-else logic currently in the ptd_create_ggplot() function.
It does this in two ways:

* By providing a fallback value (`ggplot2::waiver()`) for the `y_axis_labels` object, it allows a whole layer of logic that currently handles different paths for NULL/non-NULL values for `y_axis_breaks` to be removed
* It allows the built-in accuracy heuristic provided in the `scales::label_percent()` and `scales::label_number()` functions to do its job, without us hard-coding the accuracy levels based on the value of `y_axis_breaks` (which doesn't really make sense anyway).

It does still allow hard-coding of `accuracy = 0.1` for the secondary axis on percentage charts.
Though this could also be removed in future if thought to be the right thing to do.

This PR closes issue #210 and also closes issue #211 by replacing the `trans` argument to `sec_axis()` with the new argument name `transform`.

There is an associated test that no longer passes with these changes. This test does not look to actually test what it says it does, however - this needs further attention perhaps.

There is also a re-formatting of the hex_logo function under `inst/`, but with no change in functionality.
(These changes are unrelated to issues 210 or 211).