### PR TITLE
Add alt text to charts in README and vignettes

### DIFF
--- a/tests/testthat/test-ptd_create_ggplot.R
+++ b/tests/testthat/test-ptd_create_ggplot.R
@@ -326,10 +326,7 @@ test_that("it sets the colour of the points based on the type", {
   d <- data.frame(x = as.Date("2020-01-01") + 1:20, y = rnorm(20)) |>
     # introduce some special cause variation!
     dplyr::mutate(
-      across("y", \(y) dplyr::case_when(
-        x > "2020-01-15" ~ y + 0.5,
-        TRUE ~ y
-      ))
+      across("y", \(y) dplyr::if_else(.data[["x"]] > "2020-01-15", y + 0.5, y))
     )
 
   colours_neutral <- list(

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -58,7 +58,7 @@ The two charts below demonstrate the default, and how to over-ride to replicate 
 
 **R Package Default:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Data' on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 4.6, the mean as 1.94 and the lower process limit as -0.72."}
 data <- c(1, 2, 1, 2, 10, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1)
 date <- seq(as.Date("2021-03-22"), by = 1, length.out = 18)
 df <- tibble::tibble(data, date)
@@ -78,7 +78,7 @@ spc_data %>%
 
 **Over-riding to replicate "Making Data Count" Excel output:**
 
-```{r, fig.cap="An SPC chart labelled Data on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 4.6, the mean as 1.94 and the lower process limit as -0.72."}
+```{r, fig.cap="An SPC chart labelled 'Data' on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 6.95, the mean as 1.94 and the lower process limit as -3.06."}
 # setting screen_outliers = FALSE produces the same output as Excel
 spc_data <- ptd_spc(df, value_field = data, date_field = date, screen_outliers = FALSE)
 spc_data %>%
@@ -108,7 +108,7 @@ Examples of these 4 are shown below:
 
 **R Package Default:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart is broken into three sections: each with twelve grey common cause points. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of other groups. A caption states 'Some trial limits created by groups of fewer than 12 points exist.'"}
 spc_data <- ae_attendances %>%
   group_by(period) %>%
   summarise(across(attendances, sum)) %>%

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -76,7 +76,7 @@ spc_data %>%
 
 **Over-riding to replicate "Making Data Count" Excel output:**
 
-```{r}
+```{r, fig-alt="An SPC chart labelled Data on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 4.6, the mean as 1.94 and the lower process limit as -0.72."}
 # setting screen_outliers = FALSE produces the same output as Excel
 spc_data <- ptd_spc(df, value_field = data, date_field = date, screen_outliers = FALSE)
 spc_data %>%

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -108,7 +108,7 @@ Examples of these 4 are shown below:
 
 **R Package Default:**
 
-```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of another section. The process line is also split into three sections. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The dates are presented at 45 degrees to the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of another section. The process line is also split into three sections. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
 spc_data <- ae_attendances %>%
   group_by(period) %>%
   summarise(across(attendances, sum)) %>%
@@ -143,7 +143,7 @@ Text angle can be over-ridden by passing a ggplot `theme()` into the `theme_over
 
 **To re-instate 90 degree axis text:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The dates are presented at 90 degrees to the x-axis. The line chart has 36 grey common cause points on the process line. There are dashed lines for the upper and lower process limits and a solid line for the mean."}
 ae_attendances %>%
   group_by(period) %>%
   summarise(across(attendances, sum)) %>%

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -108,7 +108,7 @@ Examples of these 4 are shown below:
 
 **R Package Default:**
 
-```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart is broken into three sections: each with twelve grey common cause points. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of other groups. A caption states 'Some trial limits created by groups of fewer than 12 points exist.'"}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of another section. The process line is also split into three sections. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
 spc_data <- ae_attendances %>%
   group_by(period) %>%
   summarise(across(attendances, sum)) %>%
@@ -119,19 +119,19 @@ plot(spc_data, break_lines = "both")
 
 **just breaking the limit lines:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limit lines, that are not connected to the lines of another section. The process line is unbroken. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
 plot(spc_data, break_lines = "limits")
 ```
 
-**just breaking the limit lines:**
+**just breaking the process line:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limits, but the lines for these are unbroken between sections. The process line is however broken between sections. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
 plot(spc_data, break_lines = "process")
 ```
 
 **Over-riding to replicate "Making Data Count" Excel output:**
 
-```{r}
+```{r, fig.cap="An SPC chart labelled 'Attendances' on the y-axis, with dates from 1 April 2016 to 1 March 2019, at 1-month intervals, on the x-axis. The line chart has three sections, each with twelve grey common cause points on the process line. Each section has its own upper process limit, mean, and lower process limits, but the lines for these are unbroken between sections. The process line is also unbroken between the sections. A caption states 'Some trial limits created by groups of fewer than 12 points exist. These will become more reliable as more data is added.'"}
 plot(spc_data, break_lines = "none")
 ```
 

--- a/vignettes/deviations.Rmd
+++ b/vignettes/deviations.Rmd
@@ -1,6 +1,8 @@
 ---
 title: "Deviations from Excel defaults"
-output: rmarkdown::html_vignette
+output:
+  rmarkdown::html_vignette:
+    fig_caption: false
 vignette: >
   %\VignetteIndexEntry{Deviations from Excel defaults}
   %\VignetteEngine{knitr::rmarkdown}
@@ -76,7 +78,7 @@ spc_data %>%
 
 **Over-riding to replicate "Making Data Count" Excel output:**
 
-```{r, fig-alt="An SPC chart labelled Data on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 4.6, the mean as 1.94 and the lower process limit as -0.72."}
+```{r, fig.cap="An SPC chart labelled Data on the y-axis, with dates from 22 March 2021 to 8 April 2021, at 1-day intervals, on the x-axis. From left to right the line shows four grey common cause points followed by a single blue special cause improvement point followed by a further 12 grey common cause points. A caption reports the upper process limit as 4.6, the mean as 1.94 and the lower process limit as -0.72."}
 # setting screen_outliers = FALSE produces the same output as Excel
 spc_data <- ptd_spc(df, value_field = data, date_field = date, screen_outliers = FALSE)
 spc_data %>%


### PR DESCRIPTION
Small initial commit to check that it works - just done the 'deviations from Excel' vignette.
Can add more work if it's been done correctly.
This relates to issue #21 
