### PR TITLE
do not render the code chunk as it results in large file size

### DIFF
--- a/vignettes/NHSRplotthedots.Rmd
+++ b/vignettes/NHSRplotthedots.Rmd
@@ -194,7 +194,7 @@ This takes the same arguments as `plot` (and `ptd_create_ggplot`).
 
 For instance, we can use the code from the last example to make an interactive version:
 
-```{r plotly}
+```{r plotly, eval=FALSE}
 ptd_spc(
   facet_set,
   value_field = breaches,


### PR DESCRIPTION
was getting notes about the docs/ folder being over 4MB. seems like it was entirely due to the plotly example. so added eval=FALSE to that chunk
